### PR TITLE
Update control, fix dependency of mysql-client → virtual-mysql-client

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Package: domjudge-domserver
 Architecture: all
 Depends: domjudge-common (= ${source:Version}), apache2 | httpd,
  libapache2-mod-php5, php5-mysql, php5-cli, php5-json, php5-gd,
- zip, unzip, dbconfig-common, mysql-client, ${misc:Depends}
+ zip, unzip, dbconfig-common, virtual-mysql-client, ${misc:Depends}
 Recommends: php5-curl, ntp, mysql-server | virtual-mysql-server, phpmyadmin
 Description: programming contest jury system (server)
  DOMjudge is a jury system for running a programming contest. It allows


### PR DESCRIPTION
Hi,
i had to change back from mariadb-client to mysql-client because of this.
And the Server too because of our salt-managed environment which does allow only one flavour of mysql.

thx, bodo