### PR TITLE
Docker: Allow setting passwords through files

### DIFF
--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -58,6 +58,23 @@ The following environment variables are supported by the container:
 * `DJ_SKIP_MAKE` (defaults to `0`): set to `1` to skip the maintainer setup and install commands. This will speed up the startup process of the container and is useful if this is already done before.
 * `DJ_DB_INSTALL_BARE` (defaults to `0`): set to `1` to do a `bare-install` for the database instead of a normal `install`.
 
+#### Passwords through files
+
+In order to not specify sensitive information through environment variables, the variables `MYSQL_PASSWORD_FILE` and `MYSQL_ROOT_PASSWORD_FILE` can be used to set a path to a file to read the passwords from. This is suitable to use together with [docker compose's secrets](https://docs.docker.com/compose/compose-file/#secrets-configuration-reference):
+
+```yml
+...
+services:
+    domjudge-contributor:
+        image: domjudge/domjudge-contributor:${DOMJUDGE_VERSION}
+        secrets:
+            - domjudge-mysql-pw
+        ...
+        environment:
+            MYSQL_PASSWORD_FILE: /run/secrets/domjudge-mysql-pw
+        ...
+```
+
 ### Commands
 
 This container supports a few commands. You can run all commands using the following syntax:

--- a/docker-contributor/scripts/bin/submit-test-programs
+++ b/docker-contributor/scripts/bin/submit-test-programs
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+function file_or_env {
+    file=${1}_FILE
+    if [ ! -z "${!file}" ]; then
+        cat "${!file}"
+    else
+        echo -n ${!1}
+    fi
+}
+
+MYSQL_PASSWORD=$(file_or_env MYSQL_PASSWORD)
+MYSQL_ROOT_PASSWORD=$(file_or_env MYSQL_ROOT_PASSWORD)
+
 USER_EXISTS=$(mysql -h${MYSQL_HOST} -uroot -p${MYSQL_ROOT_PASSWORD} -AN -D${MYSQL_DATABASE} -e "SELECT COUNT(*) FROM user WHERE username = 'dummy'")
 if [ "${USER_EXISTS}" -eq "0" ]
 then

--- a/docker-contributor/scripts/start.sh
+++ b/docker-contributor/scripts/start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -e
 
+function file_or_env {
+    file=${1}_FILE
+    if [ ! -z "${!file}" ]; then
+        cat "${!file}"
+    else
+        echo -n ${!1}
+    fi
+}
+
 echo "[..] Setting timezone"
 ln -snf /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime
 echo ${CONTAINER_TIMEZONE} > /etc/timezone
@@ -31,6 +40,9 @@ then
   echo "DOMjudge sources not found. Did you add a volume with your DOMjudge checkout at /domjudge?"
   exit 1
 fi
+
+MYSQL_PASSWORD=$(file_or_env MYSQL_PASSWORD)
+MYSQL_ROOT_PASSWORD=$(file_or_env MYSQL_ROOT_PASSWORD)
 
 echo "[..] Updating database credentials file"
 echo "dummy:${MYSQL_HOST}:${MYSQL_DATABASE}:${MYSQL_USER}:${MYSQL_PASSWORD}" > etc/dbpasswords.secret

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,6 +60,23 @@ The following environment variables are supported by the `domserver` container:
 * `MYSQL_DATABASE` (defaults to `domjudge`): set the database to use.
 * `DJ_DB_INSTALL_BARE` (defaults to `0`): set to `1` to do a `bare-install` for the database instead of a normal `install`.
 
+#### Passwords through files
+
+In order to not specify sensitive information through environment variables, the variables `MYSQL_PASSWORD_FILE` and `MYSQL_ROOT_PASSWORD_FILE` can be used to set a path to a file to read the passwords from. This is suitable to use together with [docker compose's secrets](https://docs.docker.com/compose/compose-file/#secrets-configuration-reference):
+
+```yml
+...
+services:
+    domserver:
+        image: domjudge/domserver:${DOMJUDGE_VERSION}
+        secrets:
+            - domjudge-mysql-pw
+        ...
+        environment:
+            MYSQL_PASSWORD_FILE: /run/secrets/domjudge-mysql-pw
+        ...
+```
+
 #### Commands
 
 The `domserver` container supports a few commands. You can run all commands using the following syntax:
@@ -108,7 +125,7 @@ The following environment variables are supported by the `judgehost` container:
 * `CONTAINER_TIMEZONE` (defaults to `Europe/Amsterdam`): allows you to change the timezone used inside the container.
 * `DOMSERVER_BASEURL` (defaults to `http://domserver/`): base URL where the domserver can be found. The judgehost uses this to connect to the API. **Do not add `api` yourself, as the container will do this!**
 * `JUDGEDAEMON_USERNAME` (defaults to `judgehost`): username used to connect to the API.
-* `JUDGEDAEMON_PASSWORD` (defaults to `password`): password used to connect to the API. This should be the value of the `judgehost` password you wrote down earlier.
+* `JUDGEDAEMON_PASSWORD` (defaults to `password`): password used to connect to the API. This should be the value of the `judgehost` password you wrote down earlier. Like with the mysql passwords, you can also set `JUDGEDAEMON_PASSWORD_FILE` to a path containing the password instead.
 * `DAEMON_ID` (defaults to `0`): ID of the daemon to use for this judgedaemon. If you start multiple judgehosts on one (physical) machine, make sure each one has a different `DAEMON_ID`.
 
 ## Building the images

--- a/docker/domserver/scripts/start.sh
+++ b/docker/domserver/scripts/start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -e
 
+function file_or_env {
+    file=${1}_FILE
+    if [ ! -z "${!file}" ]; then
+        cat "${!file}"
+    else
+        echo -n ${!1}
+    fi
+}
+
 echo "[..] Setting timezone"
 ln -snf /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime
 echo ${CONTAINER_TIMEZONE} > /etc/timezone
@@ -25,6 +34,9 @@ if [[ ! -d webapp ]]
 then
 	USE_LEGACY=1
 fi
+
+MYSQL_PASSWORD=$(file_or_env MYSQL_PASSWORD)
+MYSQL_ROOT_PASSWORD=$(file_or_env MYSQL_ROOT_PASSWORD)
 
 echo "[..] Updating database credentials file"
 echo "dummy:${MYSQL_HOST}:${MYSQL_DATABASE}:${MYSQL_USER}:${MYSQL_PASSWORD}" > etc/dbpasswords.secret

--- a/docker/judgehost/scripts/start.sh
+++ b/docker/judgehost/scripts/start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash -e
 
+function file_or_env {
+    file=${1}_FILE
+    if [ ! -z "${!file}" ]; then
+        cat "${!file}"
+    else
+        echo -n ${!1}
+    fi
+}
+
 echo "[..] Setting timezone"
 ln -snf /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime
 echo ${CONTAINER_TIMEZONE} > /etc/timezone
@@ -7,6 +16,8 @@ dpkg-reconfigure -f noninteractive tzdata
 echo "[ok] Container timezone set to: ${CONTAINER_TIMEZONE}"; echo
 
 cd /opt/domjudge/judgehost
+
+JUDGEDAEMON_PASSWORD=$(file_or_env JUDGEDAEMON_PASSWORD)
 
 echo "[..] Setting up restapi file"
 echo "default	${DOMSERVER_BASEURL}api/v4	${JUDGEDAEMON_USERNAME}	${JUDGEDAEMON_PASSWORD}" > etc/restapi.secret


### PR DESCRIPTION
I use docker compose and rather not have my passwords written into my configuration. [docker compose's secrets](https://docs.docker.com/compose/compose-file/#secrets-configuration-reference) offer a nice solution for this, but require that the secrets are read from a file.

This PR adds this functionality without breaking any existing setup: If `MYSQL_PASSWORD_FILE` or the like is not specified, `MYSQL_PASSWORD` is used.

I copied the function into every file using it. If you’d prefer a certain way to share the function between files, I’ll be happy to do so.