### PR TITLE
Install fontconfig for rst2pdf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: DOMjudge Developers <team@domjudge.org>
 Uploaders: Jaap Eldering <jaap@jaapeldering.nl>, Keith Johnson <kj@ubergeek42.com>, Thijs Kinkhorst <thijs@debian.org>
 Build-Depends: libcurl4-gnutls-dev, libmagic-dev,
  debhelper (>= 12), libcgroup-dev, zip, libjsoncpp-dev
-Build-Depends-Indep: python-sphinx, python-sphinx-rtd-theme, rst2pdf
+Build-Depends-Indep: python-sphinx, python-sphinx-rtd-theme, rst2pdf, fontconfig
 Homepage: https://www.domjudge.org
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/DOMjudge/domjudge-packaging.git

--- a/docker-contributor/Dockerfile
+++ b/docker-contributor/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     php7.2-gmp php7.2-xml php7.2-mbstring php-xdebug \
     bsdmainutils ntp \
     linuxdoc-tools linuxdoc-tools-text groff \
-    python3-sphinx python3-sphinx-rtd-theme python3-yaml python3-pip \
+    python3-sphinx python3-sphinx-rtd-theme python3-pip fontconfig python3-yaml \
     texlive-latex-recommended texlive-latex-extra \
     texlive-fonts-recommended texlive-lang-european \
     sudo debootstrap libcgroup-dev procps \
@@ -31,7 +31,6 @@ RUN apt-get update \
     supervisor apache2-utils lsb-release \
     libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev python python-pip \
     enscript lpr ca-certificates less vim \
-    && pip install Pygments \
     && rm -rf /var/lib/apt/lists/*
 
 # Needed for building the docs

--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
   devscripts shellcheck nginx libboost-regex-dev \
   php php-cli php-gd php-curl php-mysql php-json php-gmp php-zip php-xml php-mbstring php-fpm php-intl \
   # Docs \
-  python-sphinx python-sphinx-rtd-theme rst2pdf python3-yaml \
+  python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
   texlive-latex-recommended texlive-latex-extra \
   texlive-fonts-recommended texlive-lang-european \
   # Misc gitlab things \

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 	php-gmp php-xml php-mbstring \
 	sudo bsdmainutils ntp libcgroup-dev procps \
 	linuxdoc-tools linuxdoc-tools-text groff \
-	python3-sphinx python3-sphinx-rtd-theme python3-yaml python3-pip \
+	python3-sphinx python3-sphinx-rtd-theme python3-pip fontconfig python3-yaml \
 	texlive-latex-recommended texlive-latex-extra \
 	texlive-fonts-recommended texlive-lang-european \
 	libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \


### PR DESCRIPTION
The rst2pdf package uses the fc-match command from the fontconfig package, but doesn't list it as a dependency for some reason.

Fixes #56.

Also move python3-yaml to the end in a few more places, and remove duplicate pip install of `pygments` in the contributor Dockerfile.