### PR TITLE
Set $HOME with sudo in the contributor container, for rst2pdf and composer

### DIFF
--- a/docker-contributor/scripts/start.sh
+++ b/docker-contributor/scripts/start.sh
@@ -56,8 +56,9 @@ then
   echo "Skipping maintainer-mode install for DOMjudge"
 else
   echo "[..] Performing maintainer-mode install for DOMjudge"
-  sudo -u domjudge make maintainer-conf CONFIGURE_FLAGS="--with-baseurl=http://localhost/ --with-webserver-group=domjudge"
-  sudo -u domjudge make maintainer-install
+  # -H is required on Ubuntu < 19.10 to set $HOME, see https://askubuntu.com/a/1187000
+  sudo -H -u domjudge make maintainer-conf CONFIGURE_FLAGS="--with-baseurl=http://localhost/ --with-webserver-group=domjudge"
+  sudo -H -u domjudge make maintainer-install
   echo "[ok] DOMjudge installed in Maintainer-mode"; echo
 fi
 


### PR DESCRIPTION
On Ubuntu < 19.10, sudo preserves $HOME by default (see https://askubuntu.com/a/1187000).

As a result, commands such as `sudo -u domjudge make target` run make as user domjudge but leave $HOME as /root.

This causes problems; for example `sphinx-build -b pdf . build/team` fails with the following error message:

```
[ERROR] pdfbuilder.py:149 [Errno 13] Permission denied: '/root/.rst2pdf/cover.tmpl'
```

Composer also warns about the cache directory not being writable.

The `-H` (`--set-home`) option overrides sudo's default behaviour and sets $HOME to the home directory of the target user, fixing the problems.