### PR TITLE
This image can run pa11y

### DIFF
--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
   acl make zip unzip apache2-utils bsdmainutils libcurl4-gnutls-dev \
@@ -11,18 +11,18 @@ RUN apt-get update && apt-get install -y \
   # Visual regression browser \
   firefox openimageio-tools imagemagick \
   # Docs \
-  python-sphinx python-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
+  python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
   texlive-latex-recommended texlive-latex-extra \
   texlive-fonts-recommended texlive-lang-european \
   # Misc gitlab things \
   mariadb-client curl build-essential composer packaging-dev  \
-  git python-pip moreutils \
+  git python3-pip moreutils \
   # Things we'd have in the chroot \
   ca-certificates default-jre-headless pypy locales software-properties-common \
   # W3c WCAG \
-  npm libx11-xcb-dev libxtst-dev libnss3-dev libxss-dev libasound2-dev libatk-bridge2.0-dev libgtk-3-dev \
+  npm libnss3 libcups2 libxss1 libasound2 libatk1.0-0  libatk-bridge2.0-0 libpangocairo-1.0-0 libgtk-3-0 \
   # Needed NPM packages \
-  && npm install -g pa11y \
+  && npm install pa11y \
   && rm -rf /var/lib/apt/lists/*
 
 # Put the gitlab user in sudo
@@ -35,4 +35,4 @@ RUN groupadd domjudge-run
 
 # Do some extra setup
 RUN mkdir -p /run/php \
- && rm /etc/php/7.2/fpm/pool.d/www.conf
+ && rm /etc/php/7.4/fpm/pool.d/www.conf


### PR DESCRIPTION
The
```
Processing triggers for libapache2-mod-php7.4 (7.4.3-4ubuntu2.4) ...

> puppeteer@1.20.0 install /node_modules/puppeteer
> node install.js


Chromium downloaded to /node_modules/puppeteer/.local-chromium/linux-686378
npm WARN saveError ENOENT: no such file or directory, open '/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN enoent ENOENT: no such file or directory, open '/package.json'
npm WARN !invalid#1 No description
npm WARN !invalid#1 No repository field.
npm WARN !invalid#1 No README data
npm WARN !invalid#1 No license field.

+ pa11y@5.3.0
added 71 packages from 58 contributors and audited 71 packages in 20.325s
```

can be ignored for now (as it seems to run the things we needed. I will make a PR for the updated WCAG test