### PR TITLE
Path docker

### DIFF
--- a/docker-contributor/scripts/start.sh
+++ b/docker-contributor/scripts/start.sh
@@ -67,7 +67,7 @@ mount -o bind /domjudge-judgings /domjudge/output/judgings
 chown -R domjudge output
 echo "[ok] Done setting up permissions"
 
-# Sometimes when running `docker-compose up` we're to fast at this step
+# Sometimes when running `docker-compose up` we're too fast at this step
 DB_UP=3
 while [ $DB_UP -gt 0 ]
 do

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -82,6 +82,10 @@ RUN useradd -m domjudge \
 	&& chmod 755 /scripts/start.sh \
 	&& chmod 755 /scripts/bin/* \
 	&& ln -s /scripts/bin/* /usr/bin/
+
+# Make the scripts available to the root user
+ENV PATH="$PATH:/opt/domjudge/domserver/bin"
+
 CMD ["/scripts/start.sh"]
 
 # Copy supervisor files

--- a/docker/domserver/scripts/start.sh
+++ b/docker/domserver/scripts/start.sh
@@ -135,7 +135,7 @@ then
 fi
 echo "[ok] Generated credential files"; echo
 
-# Sometimes when running `docker-compose up` we're to fast at this step
+# Sometimes when running `docker-compose up` we're too fast at this step
 DB_UP=3
 while [ $DB_UP -gt 0 ]
 do

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -31,4 +31,8 @@ COPY ["judgehost/scripts", "/scripts/"]
 RUN chmod +x /scripts/start.sh \
 	&& useradd -m domjudge \
 	&& chown -R domjudge: /opt/domjudge
+
+# Make the scripts available to the root user
+ENV PATH="$PATH:/opt/domjudge/judgehost/bin"
+
 CMD ["/scripts/start.sh"]


### PR DESCRIPTION
As suggested by Thijs,

Alternative would be to already put this in /etc/bashrc (assuming people will typicly open a bash shell) if it should also work after `su domjudge` but this was the least impact while I think this covers 90% of the uses

Strangely enough does `docker run` not give a login shell, but only an interactive one.