### PR TITLE
Allow phpunit to have codecoverage

### DIFF
--- a/docker-contributor/Dockerfile
+++ b/docker-contributor/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update \
     supervisor apache2-utils lsb-release \
     libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
     enscript lpr ca-certificates less vim \
+    php-pear php-dev \
+    && pecl install pcov \
     && rm -rf /var/lib/apt/lists/*
 
 # Needed for building the docs

--- a/docker-contributor/php-config/30-pcov.ini
+++ b/docker-contributor/php-config/30-pcov.ini
@@ -1,0 +1,4 @@
+; configuration for php pcov module,
+; used for our code coverage
+; priority=30
+extension=pcov.so

--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -21,9 +21,15 @@ RUN apt-get update && apt-get install -y \
   ca-certificates default-jre-headless pypy locales software-properties-common \
   # W3c WCAG \
   npm libnss3 libcups2 libxss1 libasound2 libatk1.0-0  libatk-bridge2.0-0 libpangocairo-1.0-0 libgtk-3-0 \
+  # Code coverage for unit test
+  php-pear php-dev \
+  && pecl install pcov \
   # Needed NPM packages \
   && npm install pa11y \
   && rm -rf /var/lib/apt/lists/*
+
+# Enable pcov (code coverage) in PHP
+COPY php-config/30-pcov.ini /etc/php/7.4/cli/conf.d/
 
 # Put the gitlab user in sudo
 RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker-gitlabci/build.sh
+++ b/docker-gitlabci/build.sh
@@ -9,7 +9,9 @@ then
 fi
 
 echo "[..] Building Docker image for Gitlab CI..."
-docker build -t domjudge/gitlabci:${VERSION} - <Dockerfile
+cp -r ../docker-contributor/php-config ./
+docker build -t domjudge/gitlabci:${VERSION} . 
+rm -r php-config
 echo "[ok] Done building Docker image for Gitlab CI"
 
 echo "All done. Image domjudge/gitlabci:${VERSION} created"


### PR DESCRIPTION
I haven't tested this with PHPstorm yet, but if doing this manually in the container it works together with:
https://github.com/DOMjudge/domjudge/pull/954 or https://github.com/DOMjudge/domjudge/pull/952

@nickygerritsen I think you're using this the most (the image)