### PR TITLE
Manually deploy release dockers to DockerHUB

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ variables:
   GITLABCI_VERSION:    "2.1"
   GITLABCI_IMAGE:      "gitlabci"
   CONTRIBUTOR_IMAGE:   "domjudge/domjudge-contributor"
+  DOMJUDGE_VERSION:
+    value:             "M.m.pp"
+    description:       "The DOMjudge version, Change this variable to 7.3.3 to release the 7.3.3 dockers. The file should be available on the domjudge.org webserver."
 
 # Docker Login steps
 .release_template: &release_docker
@@ -59,7 +62,6 @@ release-ci:
   <<: *registry_dockerhub
   <<: *ci_template
   only:
-  only:
     refs:
       - master
     changes:
@@ -88,4 +90,20 @@ release-contributor:
     - cd docker-contributor
     - docker build -t $CONTRIBUTOR_IMAGE .
     - docker push $CONTRIBUTOR_IMAGE
+
+release-DOMjudge:
+  <<: *registry_dockerhub
+  when: manual
+  only:
+    - master
+  script:
+    - cd docker
+    - sh ./build.sh $DOMJUDGE_VERSION
+    - >
+      for IMG in domserver judgehost default-judgehost-chroot; do
+        docker push domjudge/$IMG:$DOMJUDGE_VERSION
+        if [ ! -z ${LATEST} ]; then
+          docker push domjudge/$IMG:latest
+        fi
+      done
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+if [[ ! -z ${CI} ]]
+then
+        set -euxo pipefail
+        export PS4='(${0}:${LINENO}): - [$?] $ '
+fi
+
 VERSION=$1
 if [[ -z ${VERSION} ]]
 then
@@ -13,7 +19,7 @@ FILE=domjudge.tar.gz
 
 echo "[..] Downloading DOMjudge version ${VERSION}..."
 
-if ! curl -f -s -o ${FILE} ${URL}
+if ! wget ${URL} -O ${FILE}
 then
 	echo "[!!] DOMjudge version ${VERSION} file not found on https://www.domjudge.org/releases"
 	exit 1
@@ -28,7 +34,7 @@ echo "[ok] Done building Docker image for domserver"
 echo "[..] Building Docker image for judgehost using intermediate build image..."
 docker build -t domjudge/judgehost:${VERSION}-build -f judgehost/Dockerfile.build .
 docker rm -f domjudge-judgehost-${VERSION}-build > /dev/null 2>&1 || true
-docker run -it --name domjudge-judgehost-${VERSION}-build --privileged domjudge/judgehost:${VERSION}-build
+docker run --name domjudge-judgehost-${VERSION}-build --privileged domjudge/judgehost:${VERSION}-build
 docker cp domjudge-judgehost-${VERSION}-build:/chroot.tar.gz .
 docker cp domjudge-judgehost-${VERSION}-build:/judgehost.tar.gz .
 docker rm -f domjudge-judgehost-${VERSION}-build


### PR DESCRIPTION
This is only triggered from master, in GitLab there is a button to
trigger the release.

The current docker:latest image does not have curl, because of this the
`-s` option is removed which yields the problem that when the server
does not have the release but returns a page we will try to unpack that
page. As thats a failure its fine for now. Additionally this assumes
that if you try to build locally you need wget.