### PR TITLE
Manual on the created debs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,9 @@
+include: '.release_debs.yml'
+
 image: docker:latest
 
 stages:
-  - testing
+  - test
   - release
 
 variables:
@@ -19,7 +21,7 @@ variables:
 
 .registry_template: &registry_gitlab
   <<: *release_docker
-  stage: testing
+  stage: test
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
@@ -30,7 +32,7 @@ variables:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_ACCESS_TOKEN
 
 .job_template: &job_check-pr
-  stage: testing
+  stage: test
   services:
     - docker:dind
   except:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -5,9 +5,10 @@
     matrix:
       - PACKAGE: ["doc","domserver","judgehost"]
   script:
-    - curl -o - https://www.domjudge.org/repokey.asc | sudo apt-key add -
+    - apt update; apt install curl
+    - curl -o - https://www.domjudge.org/repokey.asc | apt-key add -
     - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
-    - apt update; apt install domserver-"$PACKAGE"
+    - apt install domserver-"$PACKAGE"
     - apt list domjudge*
 
 debian-debs-stab:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -5,10 +5,10 @@
     matrix:
       - PACKAGE: ["doc","domserver","judgehost"]
   script:
-    - apt update; apt install -y curl gnupg
+    - apt update; apt install -y curl gnupg apt-transport-https
     - curl -o - https://www.domjudge.org/repokey.asc | apt-key add -
-    - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
-    - apt update; apt install -y domserver-"$PACKAGE"
+    - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/domjudge.list
+    - apt update; apt install -y domjudge-"$PACKAGE"
     - apt list domjudge*
 
 debian-debs-stab:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -8,7 +8,7 @@
     - apt update; apt install -y curl gnupg
     - curl -o - https://www.domjudge.org/repokey.asc | apt-key add -
     - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
-    - apt install -y domserver-"$PACKAGE"
+    - apt update; apt install -y domserver-"$PACKAGE"
     - apt list domjudge*
 
 debian-debs-stab:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -5,7 +5,7 @@
     matrix:
       - PACKAGE: ["doc","domserver","judgehost"]
   script:
-    - apt update; apt install -y curl
+    - apt update; apt install -y curl gnupg
     - curl -o - https://www.domjudge.org/repokey.asc | apt-key add -
     - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
     - apt install -y domserver-"$PACKAGE"

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -12,17 +12,17 @@
 
 debian-debs-stab:
   <<: *debs
-  image: debian/stable
+  image: debian:stable
 
 debian-debs-oldstab:
   <<: *debs
-  image: debian/oldstable
+  image: debian:oldstable
 
 ubuntu-debs-latest:
   <<: *debs
-  image: ubuntu/latest
+  image: ubuntu:latest
 
 ubuntu-debs-rolling:
   <<: *debs
-  image: debian/rolling
+  image: debian:rolling
 

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -25,5 +25,5 @@ ubuntu-debs-latest:
 
 ubuntu-debs-rolling:
   <<: *debs
-  image: debian:rolling
+  image: ubuntu:rolling
 

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -5,10 +5,10 @@
     matrix:
       - PACKAGE: ["doc","domserver","judgehost"]
   script:
-    - apt update; apt install curl
+    - apt update; apt install -y curl
     - curl -o - https://www.domjudge.org/repokey.asc | apt-key add -
     - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
-    - apt install domserver-"$PACKAGE"
+    - apt install -y domserver-"$PACKAGE"
     - apt list domjudge*
 
 debian-debs-stab:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -1,7 +1,5 @@
 .debs_template: &debs
   stage: test
-  only:
-    - master
   when: manual
   parallel:
     matrix:

--- a/.release_debs.yml
+++ b/.release_debs.yml
@@ -1,0 +1,30 @@
+.debs_template: &debs
+  stage: test
+  only:
+    - master
+  when: manual
+  parallel:
+    matrix:
+      - PACKAGE: ["doc","domserver","judgehost"]
+  script:
+    - curl -o - https://www.domjudge.org/repokey.asc | sudo apt-key add -
+    - echo "deb     https://domjudge.org/debian unstable/" >> /etc/apt/sources.list.d/tmp
+    - apt update; apt install domserver-"$PACKAGE"
+    - apt list domjudge*
+
+debian-debs-stab:
+  <<: *debs
+  image: debian/stable
+
+debian-debs-oldstab:
+  <<: *debs
+  image: debian/oldstable
+
+ubuntu-debs-latest:
+  <<: *debs
+  image: ubuntu/latest
+
+ubuntu-debs-rolling:
+  <<: *debs
+  image: debian/rolling
+


### PR DESCRIPTION
Part of the jobs to automate new releases. This can only be triggered from master, when the new debs are created these jobs can be used to see if there are installation issues on debian like distros.

Implemented tests:
- Ubuntu LTS
- Ubuntu latest
- Debian stable
- Debian oldstable

In GitLab there is a button to trigger the pipeline.

Also renamed the stage to the default test.

This is optional to test the debs after they already have been created.