### PR TITLE
Use dumb-init for judgehost dockerfile to prevent zombie process accumulation

### DIFF
--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -13,6 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Install required packages for running of judgehost
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
+	dumb-init \
 	acl zip unzip supervisor sudo procps libcgroup1 \
 	php-cli php-zip php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring python3 \
@@ -35,4 +36,5 @@ RUN chmod +x /scripts/start.sh \
 # Make the scripts available to the root user
 ENV PATH="$PATH:/opt/domjudge/judgehost/bin"
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/scripts/start.sh"]


### PR DESCRIPTION
Currently zombie processes may accumulate as mentioned in #13 due to the lack of a proper init system to deal with them. This change proposes using dumb-init as a lightweight init system to deal with these processes.