### PR TITLE
fix formatter of variables in supervisord command

### DIFF
--- a/docker-contributor/supervisor/judgedaemon.conf
+++ b/docker-contributor/supervisor/judgedaemon.conf
@@ -1,7 +1,7 @@
 [program:judgedaemon]
-process_name=judgedaemon%(process_num)
+process_name=judgedaemon%(process_num)s
 numprocs=2
-command=/domjudge/bin/judgedaemon -n %(process_num)
+command=/domjudge/bin/judgedaemon -n %(process_num)s
 user=domjudge
 autostart=true
 autorestart=true

--- a/docker-contributor/supervisor/judgedaemonextra.conf
+++ b/docker-contributor/supervisor/judgedaemonextra.conf
@@ -1,8 +1,8 @@
 [program:judgedaemonextra]
-process_name=judgedaemon%(process_num)
+process_name=judgedaemon%(process_num)s
 numprocs=2
 numprocs_start=2
-command=/domjudge/bin/judgedaemon -n %(process_num)
+command=/domjudge/bin/judgedaemon -n %(process_num)s
 user=domjudge
 autostart=false
 autorestart=true


### PR DESCRIPTION
See: http://supervisord.org/configuration.html#program-x-section-values
for full example. The variable num_procs needs a formatter to be
displayed.