### PR TITLE
Decrease image size by using smaller debian image

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest-slim AS domserver-build
+FROM debian:stable-slim AS domserver-build
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -38,7 +38,7 @@ ADD domserver/build.sh /domjudge-src
 RUN /domjudge-src/build.sh
 
 # Now create an image with the actual build in it
-FROM debian:latest
+FROM debian:stable-slim
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian-slim:latest AS domserver-build
+FROM debian:latest-slim AS domserver-build
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest AS domserver-build
+FROM debian-slim:latest AS domserver-build
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian-slim:latest
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian-slim:latest
+FROM debian:latest-slim
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:stable
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest-slim
+FROM debian:stable-slim
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian:latest-slim
+FROM debian:stable-slim
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian-slim:latest
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian-slim:latest
+FROM debian:latest-slim
 MAINTAINER DOMjudge team <team@domjudge.org>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/judgehost/Dockerfile.chroot
+++ b/docker/judgehost/Dockerfile.chroot
@@ -1,8 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install \
-  ca-certificates default-jre-headless pypy locales \
-  software-properties-common \
+  ca-certificates default-jre-headless pypy3 locales \
   && rm -rf /var/lib/apt/lists/*
 
 RUN chmod a-s \


### PR DESCRIPTION
This should also lower the amount of CVEs in the snyk dashboard.


I still need to think about a good way to test if this does work as expected, so this is just to see if the build succeeds.