### PR TITLE
Faketime

### DIFF
--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   # W3c test \
   httrack \
   # Visual regression browser \
-  cutycapt xvfb openimageio-tools imagemagick \
+  faketime cutycapt xvfb openimageio-tools imagemagick \
   # Docs \
   python3-sphinx python3-sphinx-rtd-theme rst2pdf fontconfig python3-yaml \
   texlive-latex-recommended texlive-latex-extra \


### PR DESCRIPTION
This will be used for the visual regression test,

It is now possible to do:
faketime -f "2021-01-01 00:10:10" bash

which will freeze the clock for that shell (but not the parent shells) so the tests can not have regression when one test is ran on a different time.

See https://www.systutorials.com/docs/linux/man/1-faketime/