### PR TITLE
If we start a manual job we expect it to work.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,7 @@ release-contributor:
 release-DOMjudge:
   <<: *registry_dockerhub
   when: manual
+  allow_failure: false
   only:
     - main
   script:


### PR DESCRIPTION
See: https://docs.gitlab.com/ee/ci/yaml/#allow_failure and an example
usecase:
https://gitlab.com/DOMjudge/domjudge-packaging/-/pipelines/377595065