### PR TITLE
Also build the contributor image for linux/arm64/v8, needed by M1(/pro/max) Mac's

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,11 @@ variables:
   except:
     - main
 
+.matrix_contributor_template: &matrix_contributor_template
+  parallel:
+    matrix:
+      - ARCH: [amd64, arm64v8]
+
 .job_template: &ci_template
   script:
     - cd docker-gitlabci
@@ -75,16 +80,19 @@ release-ci:
 
 check-pr-contributor:
   <<: *job_check-pr
+  <<: *matrix_contributor_template
   only:
     changes:
       - .gitlab-ci.yml
       - docker-contributor/**/*
   script:
     - cd docker-contributor
-    - docker build .
+    - docker pull $CONTRIBUTOR_IMAGE:${ARCH} || true
+    - docker build --build-arg ARCH=${ARCH}/ .
 
-release-contributor:
+release-contributor-arch:
   <<: *registry_dockerhub
+  <<: *matrix_contributor_template
   only:
     refs:
       - main
@@ -93,8 +101,23 @@ release-contributor:
       - docker-contributor/**/*
   script:
     - cd docker-contributor
-    - docker build -t $CONTRIBUTOR_IMAGE .
-    - docker push $CONTRIBUTOR_IMAGE
+    - docker pull $CONTRIBUTOR_IMAGE:${ARCH} || true
+    - docker build -t $CONTRIBUTOR_IMAGE:${ARCH} --build-arg ARCH=${ARCH}/ .
+    - docker push $CONTRIBUTOR_IMAGE:${ARCH}
+
+release-contributor-latest:
+  <<: *registry_dockerhub
+  only:
+    refs:
+      - main
+    changes:
+      - .gitlab-ci.yml
+      - docker-contributor/**/*
+  needs:
+    - release-contributor-arch
+  script:
+    - docker manifest create $CONTRIBUTOR_IMAGE:latest -a $CONTRIBUTOR_IMAGE:amd64 -a $CONTRIBUTOR_IMAGE:arm64v8
+    - docker manifest push $CONTRIBUTOR_IMAGE:latest
 
 release-DOMjudge:
   <<: *registry_dockerhub

--- a/docker-contributor/Dockerfile
+++ b/docker-contributor/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:focal
+ARG ARCH=
+FROM ${ARCH}ubuntu:focal
 LABEL maintainer="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
This should, together with a PR I will create shortly on the main repo, allow us to build an arm64 version of the contributor image.

I did build it locally (which also uses qemu) and it builds. I can also run it (with qemu again) and the container starts up, builds everything, creates a chroot and starts all services. Submitting worked, but judging seems to hang. I'm thinking this is because of qemu. When I get my arm64 Mac (in ~2 weeks) I will test if it works there natively.

Note that building using qemu is a lot slower (for the arm64 image that is), but GItLab does not have native arm64 hardware, so it seems like the best approach for now.

Later we *could* also publish arm64 versions of the main images, but I'm not sure if that will be used in general. I hope no one is crazy enough to run domserver or judgehosts on an M1 Mac and other arm64 hardware is quite limited (there is AWS Graviton, but that's about it). Doing the main images also requires some more work, since we are building them in two steps.