### PR TITLE
Add HEALTHCHECK to domserver Docker container

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim AS domserver-build
-MAINTAINER DOMjudge team <team@domjudge.org>
+LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -39,7 +39,7 @@ RUN /domjudge-src/build.sh
 
 # Now create an image with the actual build in it
 FROM debian:stable-slim
-MAINTAINER DOMjudge team <team@domjudge.org>
+LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
 	CONTAINER_TIMEZONE=Europe/Amsterdam \
@@ -84,5 +84,8 @@ RUN chmod 700 /configure.sh && /configure.sh && rm -f /configure.sh
 
 # Expose HTTP port
 EXPOSE 80
+
+# Healthchecking script
+HEALTHCHECK --interval=10s --timeout=10s --start-period=30s --retries=3 CMD [ "/scripts/bin/healthcheck" ]
 
 CMD ["/scripts/start.sh"]

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -54,7 +54,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Install required packages for running of domserver
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	acl zip unzip supervisor mariadb-client apache2-utils \
+	acl curl zip unzip supervisor mariadb-client apache2-utils \
 	nginx php-cli php-fpm php-zip \
 	php-gd php-curl php-mysql php-json php-intl \
 	php-gmp php-xml php-mbstring php-ldap \

--- a/docker/domserver/scripts/bin/healthcheck
+++ b/docker/domserver/scripts/bin/healthcheck
@@ -13,7 +13,10 @@ for service in "${SERVICES[@]}"; do
     fi
 done
 
-if php -r 'exit(@file_get_contents("http://localhost/api/") === false ? 1 : 0);'; then
+# This script has access to $WEBAPP_BASEURL, but not to the sanity checks done by 50-domejudge. So we fallback looking
+# at the configuration file where this path is stored.
+BASEURL=$(grep domjudge.baseurl /opt/domjudge/domserver/webapp/config/static.yaml | awk '{ print $2 }')
+if curl --silent --fail "$BASEURL/api" >/dev/null; then
     printf "http ok"
 else
     printf "http error"

--- a/docker/domserver/scripts/bin/healthcheck
+++ b/docker/domserver/scripts/bin/healthcheck
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SERVICES=(nginx php)
+
+ret=0
+for service in "${SERVICES[@]}"; do
+    status=$(supervisorctl status "$service" | awk '{print $2}')
+    if [ "$status" = "RUNNING" ]; then
+        printf "%s ok | " "$service"
+    else
+        printf "%s %s | " "$service" "$status"
+        ret=1
+    fi
+done
+
+if php -r 'exit(@file_get_contents("http://localhost/api/") === false ? 1 : 0);'; then
+    printf "http ok"
+else
+    printf "http error"
+    ret=1
+fi
+
+exit $ret

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable
-MAINTAINER DOMjudge team <team@domjudge.org>
+LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
 	CONTAINER_TIMEZONE=Europe/Amsterdam \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM debian:stable-slim
-MAINTAINER DOMjudge team <team@domjudge.org>
+LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
When running the Docker container for domserver, it is possible that one of nginx or php-fpm crashes/stops working. When this happens from outside the container the effects can be quite mysterious. Adding an health check allows the user to diagnose more quickly what happened.

Running `docker ps`, in the column `STATUS` it is shown: `Up X minutes (healthy)` or `Up X minutes (unhealthy)` depending on the exit code of the health check script. To further diagnose the problem one can run `docker inspect domserver` (optionally piped to `jq '.[0].State.Health'`) and this will report diagnostic information like:

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2021-12-19T19:22:53.555071655+01:00",
      "End": "2021-12-19T19:22:54.012109556+01:00",
      "ExitCode": 0,
      "Output": "nginx ok | php ok | http ok"
    },
    ...
  ]
}
```

This health check probes supervisord for the status of the two services (nginx and php-fpm), as well as tries to reach the API with an HTTP request. To perform this HTTP request I've used `php -r` since in the image there isn't curl nor wget. My PHP skills are crap, I won't be surprised if there's a better way to do that.

This commit also fixes the deprecated `MAINTAINER` labels in the various Dockerfiles.

----

Some context: we were running DJ in the docker container while suddenly the server switched off (probably due to a power loss). When it got back on the docker container restarted automatically but php-fpm failed to start logging:

```log
[14-Dec-2021 14:49:05] ERROR: Another FPM instance seems to already listen on /var/run/php-fpm-domjudge.sock
[14-Dec-2021 14:49:05] ERROR: FPM initialization failed
```

From the outside the result was a 502 from "nginx", but from which nginx was not clear since we also had nginx running outside docker. And we were a bit confused by the fact that the container was still running fine (or at least we initially thought). We could diagnose the problem much more quickly if `docker ps` showed us that the container was not healthy. Why php-fpm couldn't start automatically is still a mystery to me, since that file (at the moment at least) does not exist. I'll try to further investigate this later.