### PR TITLE
Add support for switching PHP version in contributor container.

### DIFF
--- a/docker-contributor/Dockerfile
+++ b/docker-contributor/Dockerfile
@@ -12,7 +12,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
   FPM_MAX_CHILDREN=40 \
   DJ_SKIP_MAKE=0 \
   DJ_DB_INSTALL_BARE=0 \
-  PHPSUPPORTED="7.2 7.3 8.0 8.1" \
+  PHPSUPPORTED="7.2 7.3 7.4 8.0 8.1" \
+  DEFAULTPHPVERSION="8.1" \
   APTINSTALL="apt install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 
 # Install required packages and clean up afterwards to make this image layer smaller
@@ -22,20 +23,18 @@ RUN apt update \
     gcc g++ make zip unzip mariadb-client \
     nginx php7.4 php7.4-cli php7.4-fpm php7.4-zip \
     php7.4-gd php7.4-curl php7.4-mysql php7.4-json php7.4-intl \
-    php7.4-gmp php7.4-xml php7.4-mbstring php-xdebug \
+    php7.4-gmp php7.4-xml php7.4-mbstring php-xdebug php-pcov \
     bsdmainutils ntp \
     linuxdoc-tools linuxdoc-tools-text groff \
     python3-sphinx python3-sphinx-rtd-theme python3-pip fontconfig python3-yaml \
     texlive-latex-recommended texlive-latex-extra \
     texlive-fonts-recommended texlive-lang-european latexmk \
     sudo debootstrap libcgroup-dev procps \
-    default-jre-headless \
-    default-jdk ghc fp-compiler \
+    default-jre-headless default-jdk \
     supervisor apache2-utils lsb-release \
     libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
     enscript lpr ca-certificates less vim \
     php-pear php-dev software-properties-common \
-    && pecl install pcov \
     && rm -rf /var/lib/apt/lists/*
 
 # Needed for building the docs
@@ -61,17 +60,28 @@ RUN apt update && \
 # Install all supported PHP versions
 RUN add-apt-repository ppa:ondrej/php -y && apt update
 RUN for VERSION in $PHPSUPPORTED; do \
-        $APTINSTALL php${VERSION}; \
+        if [ "${VERSION}" != "7.4" ]; then \
+            $APTINSTALL php${VERSION}; \
+        fi; \
     done
 RUN PACKAGES=$(dpkg-query -f '${binary:Package}\n' -W|grep "^php.*-"); \
     for PACKAGE in $PACKAGES; do \
         PACKAGEALLVERSIONS="" && \
         for VERSION in $PHPSUPPORTED; do \
-            PACKAGEALLVERSIONS="$PACKAGEALLVERSIONS php${VERSION}-${PACKAGE#php*-}"; \
+            if [ "${VERSION}" != "7.4" ]; then \
+                PACKAGEALLVERSIONS="$PACKAGEALLVERSIONS php${VERSION}-${PACKAGE#php*-}"; \
+            fi; \
         done; \
         $APTINSTALL $PACKAGEALLVERSIONS; \
     done
-RUN update-alternatives --set php /usr/bin/php7.4
+RUN update-alternatives --set php /usr/bin/php${DEFAULTPHPVERSION}
+
+# Set up alternatives for PHP-FPM
+RUN for VERSION in $PHPSUPPORTED; do \
+        PRIORTIY=$(echo ${VERSION} | tr -d '.'); \
+        update-alternatives --install /usr/sbin/php-fpm php-fpm /usr/sbin/php-fpm${VERSION} ${PRIORTIY}; \
+    done
+RUN update-alternatives --set php-fpm /usr/sbin/php-fpm${DEFAULTPHPVERSION}
 
 # Add exposed volume
 VOLUME ["/domjudge"]
@@ -79,8 +89,13 @@ VOLUME ["/domjudge"]
 WORKDIR /domjudge
 
 # Add PHP configuration
-COPY ["php-config", "//etc/php/7.4/fpm/conf.d"]
-COPY ["php-config", "//etc/php/7.4/cli/conf.d"]
+RUN mkdir /php-config
+COPY ["php-config", "/php-config"]
+RUN for VERSION in $PHPSUPPORTED; do \
+        cp -Rf /php-config/* /etc/php/${VERSION}/cli/conf.d; \
+        cp -Rf /php-config/* /etc/php/${VERSION}/fpm/conf.d; \
+    done; \ 
+    rm -Rf /php-config
 
 # Disable Xdebug by default
 RUN phpdismod xdebug

--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -96,6 +96,7 @@ The following commands are available:
 * `submit-test-programs`: submit all test programs (by executing `make check test-stress` in the `tests` directory of the DOMjudge installation. This will also add a `dummy` user to your database if it does not exist yet. It's password will be set to `dummy`.
 * `xdebug-enable`: enable Xdebug debugging. See note below
 * `xdebug-disable`: disable Xdebug debugging. See note below
+* `switch-php <version>`: switch to using the given PHP version.
 
 Of course, you can always run `docker exec -it domjudge bash` to get a bash shell inside the container.
 

--- a/docker-contributor/php-config/30-pcov.ini
+++ b/docker-contributor/php-config/30-pcov.ini
@@ -1,4 +1,0 @@
-; configuration for php pcov module,
-; used for our code coverage
-; priority=30
-extension=pcov.so

--- a/docker-contributor/scripts/bin/switch-php
+++ b/docker-contributor/scripts/bin/switch-php
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import shlex
+import sys
+
+if os.getuid() != 0:
+    # Automatically give ourself root privileges
+    arguments = " ".join(shlex.quote(arg) for arg in sys.argv)
+    command = f"sudo {arguments}"
+    exit(os.system(command))
+
+def currentPhpVersion():
+    return os.readlink('/etc/alternatives/php').replace('/usr/bin/php', '')
+
+def supportedVersions():
+    return sorted([binary.replace('/usr/bin/php', '') for binary in glob.glob('/usr/bin/php?.?')])
+
+def usage():
+    u = f"Usage: {sys.argv[0]} <version>\n\n"
+    u += f"Supported PHP versions:\n"
+    for version in supportedVersions():
+        u += f"- {version}"
+        if version == currentPhpVersion():
+            u += " *"
+        u += "\n"
+
+    u += "\n*: currently used version"
+
+    print(u)
+
+if len(sys.argv) != 2:
+    usage()
+    exit(0)
+
+newVersion = sys.argv[1]
+
+if newVersion not in supportedVersions():
+    print(f"{newVersion} is not a supported PHP version")
+    usage()
+    exit(1)
+
+# Version is supported, switch to it
+os.system(f"update-alternatives --set php /usr/bin/php{newVersion}")
+os.system(f"update-alternatives --set php-fpm /usr/sbin/php-fpm{newVersion}")
+
+# Restart PHP FPM supervisor job
+os.system("supervisorctl restart php")
+
+print(f"Successfully switched to PHP {newVersion} and restarted PHP FPM")

--- a/docker-contributor/scripts/start.sh
+++ b/docker-contributor/scripts/start.sh
@@ -18,14 +18,17 @@ echo "[ok] Container timezone set to: ${CONTAINER_TIMEZONE}"; echo
 echo "[..] Changing nginx and PHP configuration settings"
 # Set correct settings
 sed -ri -e "s/^user.*/user domjudge;/" /etc/nginx/nginx.conf
-sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = 100M/" \
-    -e "s/^post_max_size.*/post_max_size = 100M/" \
-    -e "s/^memory_limit.*/memory_limit = 2G/" \
-    -e "s/^max_file_uploads.*/max_file_uploads = 200/" \
-    -e "s#^;date\.timezone.*#date.timezone = ${CONTAINER_TIMEZONE}#" \
-     /etc/php/7.4/fpm/php.ini
-sed -ri -e "s#^;date\.timezone.*#date.timezone = ${CONTAINER_TIMEZONE}#" \
-     /etc/php/7.4/cli/php.ini
+for VERSION in $PHPSUPPORTED
+do
+  sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = 100M/" \
+      -e "s/^post_max_size.*/post_max_size = 100M/" \
+      -e "s/^memory_limit.*/memory_limit = 2G/" \
+      -e "s/^max_file_uploads.*/max_file_uploads = 200/" \
+      -e "s#^;date\.timezone.*#date.timezone = ${CONTAINER_TIMEZONE}#" \
+      "/etc/php/${VERSION}/fpm/php.ini"
+  sed -ri -e "s#^;date\.timezone.*#date.timezone = ${CONTAINER_TIMEZONE}#" \
+      "/etc/php/${VERSION}/cli/php.ini"
+done
 echo "[ok] Done changing nginx and PHP configuration settings"; echo
 
 cd /domjudge
@@ -114,16 +117,19 @@ cp etc/nginx-conf /etc/nginx/sites-enabled/default
 # Replace nginx php socket location
 sed -i 's/server unix:.*/server unix:\/var\/run\/php-fpm-domjudge.sock;/' /etc/nginx/sites-enabled/default
 # Remove default FPM pool config and link in DOMjudge version
-if [[ -f /etc/php/7.4/fpm/pool.d/www.conf ]]
-then
-  rm /etc/php/7.4/fpm/pool.d/www.conf
-fi
-if [[ ! -f /etc/php/7.4/fpm/pool.d/domjudge.conf ]]
-then
-  ln -s /domjudge/etc/domjudge-fpm.conf /etc/php/7.4/fpm/pool.d/domjudge.conf
-fi
-# Change pm.max_children
-sed -i "s/^pm\.max_children = .*$/pm.max_children = ${FPM_MAX_CHILDREN}/" /etc/php/7.4/fpm/pool.d/domjudge.conf
+for VERSION in $PHPSUPPORTED
+do
+  if [[ -f /etc/php/${VERSION}/fpm/pool.d/www.conf ]]
+  then
+    rm "/etc/php/${VERSION}/fpm/pool.d/www.conf"
+  fi
+  if [[ ! -f /etc/php/${VERSION}/fpm/pool.d/domjudge.conf ]]
+  then
+    ln -s /domjudge/etc/domjudge-fpm.conf "/etc/php/${VERSION}/fpm/pool.d/domjudge.conf"
+  fi
+  # Change pm.max_children
+  sed -i "s/^pm\.max_children = .*$/pm.max_children = ${FPM_MAX_CHILDREN}/" "/etc/php/${VERSION}/fpm/pool.d/domjudge.conf"
+done
 
 chown domjudge: /domjudge/etc/dbpasswords.secret
 chown domjudge: /domjudge/etc/restapi.secret

--- a/docker-contributor/supervisor/php.conf
+++ b/docker-contributor/supervisor/php.conf
@@ -1,5 +1,5 @@
 [program:php]
-command=php-fpm7.4 -F
+command=php-fpm -F
 numprocs=1
 autostart=true
 autorestart=true

--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt install -y \
   libjsoncpp-dev libmagic-dev autoconf automake bats sudo debootstrap procps \
   gcc g++ default-jre-headless default-jdk ghc fp-compiler libcgroup-dev \
   devscripts shellcheck nginx libboost-regex-dev \
-  php php-cli php-gd php-curl php-mysql php-json php-gmp php-zip php-xml php-mbstring php-fpm php-intl \
+  php php-cli php-gd php-curl php-mysql php-json php-gmp php-zip php-xml php-mbstring php-fpm php-intl php-pcov \
   # W3c test \
   httrack \
   # Visual regression browser \
@@ -27,7 +27,6 @@ RUN apt update && apt install -y \
   npm libnss3 libcups2 libxss1 libasound2 libatk1.0-0  libatk-bridge2.0-0 libpangocairo-1.0-0 libgtk-3-0 \
   # Code coverage for unit test
   php-pear php-dev \
-  && pecl install pcov \
   # Needed NPM packages \
   && npm install pa11y \
   # Needed python packages \
@@ -53,9 +52,6 @@ RUN add-apt-repository ppa:ondrej/php -y && apt update && \
             $APTINSTALL php${VERSION}-${PACKAGE#php*-}; \
         done; \
     done && update-alternatives --set php /usr/bin/php7.4
-
-# Enable pcov (code coverage) in PHP
-COPY php-config/30-pcov.ini /etc/php/7.4/cli/conf.d/
 
 # Put the gitlab user in sudo
 RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Also use build in packages for pcov, since pecl is not working with multiple PHP versions.
Get rid of ghc and fp-compiler since install seems flaky and contributors don't use it anyway.