### PR TITLE
Adds documentation to dj_make_chroot call

### DIFF
--- a/docker/judgehost/chroot-and-tar.sh
+++ b/docker/judgehost/chroot-and-tar.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Add packages with -i "<apt package name>" here
+# Usage: https://github.com/DOMjudge/domjudge/blob/main/misc-tools/dj_make_chroot.in#L58-L87
 /opt/domjudge/judgehost/bin/dj_make_chroot
 
 cd /


### PR DESCRIPTION
When setting up a forked version of this repo for our own local docker build of domserver and domjudge we needed to add 

`mono-complete mono-dbg mono-vbnc` to support CSharp and Visual Basic compile/run

While the `/opt/domjudge/judgehost/bin/dj_make_chroot` was documented with a usage function it wasn't clear what the options were in this script

Ended up needing to modify this to:
```
DEBPROXY=$HTTP_PROXY /opt/domjudge/judgehost/bin/dj_make_chroot -i "mono-complete,mono-dbg,mono-vbnc" -D Debian -R buster
```