### PR TITLE
Silence spurious shellcheck error SC2153 "Possible Misspelling" in Docker startup script

### DIFF
--- a/docker/domserver/scripts/start.d/50-domjudge.sh
+++ b/docker/domserver/scripts/start.d/50-domjudge.sh
@@ -11,6 +11,9 @@ function file_or_env {
 
 cd /opt/domjudge/domserver
 
+# Check required environment variables are set (to satisfy ShellCheck)
+: "${MYSQL_HOST:?}" "${MYSQL_DATABASE:?}" "${MYSQL_USER:?}"
+
 MYSQL_PASSWORD=$(file_or_env MYSQL_PASSWORD)
 MYSQL_ROOT_PASSWORD=$(file_or_env MYSQL_ROOT_PASSWORD)
 


### PR DESCRIPTION
Error message:

```
Notice: ./docker/domserver/scripts/start.d/50-domjudge.sh:25:13: note: Possible misspelling: MYSQL_HOST may not be assigned. Did you mean MYSQL_PORT? [SC2153]
```

The environment variable MYSQL_HOST is in fact set in the Dockerfile, but ShellCheck doesn't know that.

Abort if the variable is unset (using the parameter expansion `${VAR:?message}`), to teach ShellCheck that this variable exists and to give a clear error message if somehow the variable is unset.

Also check some other variables for consistency.