### PR TITLE
Build on ubuntu 20.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: DOMjudge Developers <team@domjudge.org>
 Uploaders: Jaap Eldering <jaap@jaapeldering.nl>, Keith Johnson <kj@ubergeek42.com>, Thijs Kinkhorst <thijs@debian.org>
 Build-Depends: libcurl4-gnutls-dev, libmagic-dev,
  debhelper (>= 12), libcgroup-dev, zip, libjsoncpp-dev
-Build-Depends-Indep: python-sphinx, python-sphinx-rtd-theme, rst2pdf, fontconfig, latexmk
+Build-Depends-Indep: python3-sphinx, python3-sphinx-rtd-theme, rst2pdf, fontconfig, latexmk
 Homepage: https://www.domjudge.org
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/DOMjudge/domjudge-packaging.git


### PR DESCRIPTION
I seem to need this otherwise my builds fail, because there is no `python-sphinx` package on ubuntu 20.04 (only a `python3-sphinx`)