### PR TITLE
Switch from pip3 to apt for installing rst2pdf to fix Docker build

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -12,15 +12,12 @@ RUN apt update \
 	php-gd php-curl php-mysql php-json php-intl \
 	php-gmp php-xml php-mbstring \
 	sudo bsdmainutils ntp libcgroup-dev procps \
-	python3-sphinx python3-sphinx-rtd-theme python3-pip fontconfig python3-yaml \
+	python3-sphinx python3-sphinx-rtd-theme python3-pygments rst2pdf fontconfig python3-yaml \
 	texlive-latex-recommended texlive-latex-extra \
 	texlive-fonts-recommended texlive-lang-european latexmk \
 	libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
 	enscript lpr ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
-
-# Needed for building the docs
-RUN pip3 install pygments rst2pdf
 
 # Set up user
 RUN useradd -m domjudge


### PR DESCRIPTION
The domserver Docker build broke (output at the very end) because rst2pdf started pulling in pycario (details below).

The same issue was recently fixed in the docker-contributor image in commit 3ff4bd18c (Install dependencies for cairo., 2023-05-08), and later tweaked in commit 7fbef1250 (Mount the contributor image in the same place as the project itself., 2023-05-08).

Fix the issue in the domserver image the same way: by installing rst2pdf using apt (i.e. from the Debian archive) instead of using pip3 (i.e. from PyPI). Also switch over pygments from pip3 to apt for consistency.


More details:

The Python package rst2pdf depends on reportlab. Between versions 3.6.13 and 4.0.0 (released recently), reportlab added a hard dependency on rlPyCairo and hence pycairo (previously it was an optional dependency).[1]

But pycairo requires the following Debian packages to be installed[2]: libcairo2-dev pkg-config python3-dev

So the solution is either to install those packages (that's the approach used in commit 3ff4bd18c), or to install rst2pdf from the Debian archive (since it has complete dependency information; that's the approach used in the second commit, 7fbef1250).

[1]: https://hg.reportlab.com/hg-public/reportlab/rev/c397e87124be#l6.549
[2]: https://pycairo.readthedocs.io/en/latest/getting_started.html


Build output:

```
[..] Building Docker image for domserver...
...
#9 [domserver-build 3/8] RUN pip3 install pygments rst2pdf
#9 1.615 Requirement already satisfied: pygments in /usr/lib/python3/dist-packages (2.7.1)
#9 1.781 Collecting rst2pdf
#9 1.850   Downloading rst2pdf-0.100-py3-none-any.whl (176 kB)
#9 1.922 Requirement already satisfied: packaging in /usr/lib/python3/dist-packages (from rst2pdf) (20.9)
#9 2.617 Collecting reportlab
#9 2.639   Downloading reportlab-4.0.0-py3-none-any.whl (1.9 MB)
#9 2.762 Collecting smartypants
#9 2.780   Downloading smartypants-2.0.1-py2.py3-none-any.whl (9.9 kB)
#9 2.788 Requirement already satisfied: jinja2 in /usr/lib/python3/dist-packages (from rst2pdf) (2.11.3)
#9 2.789 Requirement already satisfied: pyyaml in /usr/lib/python3/dist-packages (from rst2pdf) (5.3.1)
#9 3.103 Collecting importlib-metadata
#9 3.120   Downloading importlib_metadata-6.6.0-py3-none-any.whl (22 kB)
#9 3.128 Requirement already satisfied: docutils in /usr/lib/python3/dist-packages (from rst2pdf) (0.16)
#9 3.290 Collecting zipp>=0.5
#9 3.306   Downloading zipp-3.15.0-py3-none-any.whl (6.8 kB)
#9 4.127 Collecting pillow>=9.0.0
#9 4.153   Downloading Pillow-9.5.0-cp39-cp39-manylinux_2_28_x86_64.whl (3.4 MB)
#9 4.277 Collecting rlPyCairo<1,>=0.2.0
#9 4.293   Downloading rlPyCairo-0.2.0-py3-none-any.whl (10 kB)
#9 4.367 Collecting freetype-py<2.4,>=2.3.0
#9 4.394   Downloading freetype_py-2.3.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (978 kB)
#9 4.514 Collecting pycairo>=1.20.0
#9 4.533   Downloading pycairo-1.23.0.tar.gz (344 kB)
#9 4.602   Installing build dependencies: started
#9 8.318   Installing build dependencies: finished with status 'done'
#9 8.320   Getting requirements to build wheel: started
#9 8.570   Getting requirements to build wheel: finished with status 'done'
#9 8.573   Installing backend dependencies: started
#9 10.47   Installing backend dependencies: finished with status 'done'
#9 10.49     Preparing wheel metadata: started
#9 10.75     Preparing wheel metadata: finished with status 'done'
#9 10.76 Building wheels for collected packages: pycairo
#9 10.77   Building wheel for pycairo (PEP 517): started
#9 11.01   Building wheel for pycairo (PEP 517): finished with status 'error'
#9 11.01   ERROR: Command errored out with exit status 1:
#9 11.01    command: /usr/bin/python3 /tmp/tmpa4zptwba_in_process.py build_wheel /tmp/tmp6v3ey36y
#9 11.01        cwd: /tmp/pip-install-jutsqcof/pycairo_014bcea835b94721b5d334676dc25bf0
#9 11.01   Complete output (12 lines):
#9 11.01   running bdist_wheel
#9 11.01   running build
#9 11.01   running build_py
#9 11.01   creating build
#9 11.01   creating build/lib.linux-x86_64-cpython-39
#9 11.01   creating build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   copying cairo/__init__.py -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   copying cairo/__init__.pyi -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   copying cairo/py.typed -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   running build_ext
#9 11.01   'pkg-config' not found.
#9 11.01   Command ['pkg-config', '--print-errors', '--exists', 'cairo >= 1.15.10']
#9 11.01   ----------------------------------------
#9 11.01   ERROR: Failed building wheel for pycairo
#9 11.01 Failed to build pycairo
#9 11.01 ERROR: Could not build wheels for pycairo which use PEP 517 and cannot be installed directly
#9 ERROR: process "/bin/sh -c pip3 install pygments rst2pdf" did not complete successfully: exit code: 1
------
 > [domserver-build 3/8] RUN pip3 install pygments rst2pdf:
#9 11.01   copying cairo/__init__.py -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   copying cairo/__init__.pyi -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   copying cairo/py.typed -> build/lib.linux-x86_64-cpython-39/cairo
#9 11.01   running build_ext
#9 11.01   'pkg-config' not found.
#9 11.01   Command ['pkg-config', '--print-errors', '--exists', 'cairo >= 1.15.10']
#9 11.01   ----------------------------------------
#9 11.01   ERROR: Failed building wheel for pycairo
#9 11.01 Failed to build pycairo
#9 11.01 ERROR: Could not build wheels for pycairo which use PEP 517 and cannot be installed directly
------
Dockerfile:23
--------------------
  21 |     
  22 |     # Needed for building the docs
  23 | >>> RUN pip3 install pygments rst2pdf
  24 |     
  25 |     # Set up user
--------------------
ERROR: failed to solve: process "/bin/sh -c pip3 install pygments rst2pdf" did not complete successfully: exit code: 1
```