### PR TITLE
Pin to bullseye as the Docker base image

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS domserver-build
+FROM debian:bullseye-slim AS domserver-build
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -35,7 +35,7 @@ COPY domserver/build.sh /domjudge-src/build.sh
 RUN /domjudge-src/build.sh
 
 # Now create an image with the actual build in it
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bullseye
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
For #150.

Current debian `stable` and `stable-slim` image has an issue on dependent package (libpcre2-8-0), The latest stable's Sphinx version is also not compatible with current DOMjudge documentation. Thus, this PR pins the base image to previous stable debian release.

I've verified that I can successfully build the images for DOMudge 8.2.1 and 8.1.4.