### PR TITLE
Fix recreating released docker containers on schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,10 @@ release-contributor-latest:
 
 release-DOMjudge:
   <<: *registry_dockerhub
-  when: manual
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      # when: always # is a default value
+    - when: manual
   allow_failure: false
   only:
     - main


### PR DESCRIPTION
See:
https://gitlab.com/DOMjudge/domjudge-packaging/-/pipelines/951713866

The job did not start as the needed job is only triggered manually. A fix for that was used from here: https://stackoverflow.com/a/64126532