### PR TITLE
Use bookworm for building Docker image

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS domserver-build
+FROM debian:bookworm-slim AS domserver-build
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,12 +12,15 @@ RUN apt update \
 	php-gd php-curl php-mysql php-json php-intl \
 	php-gmp php-xml php-mbstring \
 	sudo bsdmainutils ntp libcgroup-dev procps \
-	python3-sphinx python3-sphinx-rtd-theme python3-pygments rst2pdf fontconfig python3-yaml \
+	python3-venv fontconfig \
 	texlive-latex-recommended texlive-latex-extra \
-	texlive-fonts-recommended texlive-lang-european latexmk \
+	texlive-fonts-recommended texlive-lang-european latexmk tex-gyre \
 	libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
 	enscript lpr ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Use venv to install latest Sphinx. 6.1.0 or higher is required to build DOMjudge docs.
+RUN python3 -m venv /venv && . /venv/bin/activate && pip3 install sphinx sphinx-rtd-theme rst2pdf
 
 # Set up user
 RUN useradd -m domjudge
@@ -35,7 +38,7 @@ COPY domserver/build.sh /domjudge-src/build.sh
 RUN /domjudge-src/build.sh
 
 # Now create an image with the actual build in it
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker/domserver/build.sh
+++ b/docker/domserver/build.sh
@@ -1,9 +1,12 @@
 #!/bin/sh -eu
 
+# Use venv to use latest Sphinx. 6.1.0 or higher is required to build DOMjudge docs.
+. /venv/bin/activate
+
 cd /domjudge-src/domjudge*
 chown -R domjudge: .
 # If we used a local source tarball, it might not have been built yet
-sudo -u domjudge make dist
+sudo -u domjudge sh -c '. /venv/bin/activate && make dist'
 sudo -u domjudge ./configure -with-baseurl=http://localhost/
 
 # Passwords should not be included in the built image. We create empty files here to prevent passwords from being generated.
@@ -25,5 +28,5 @@ then
 	rm /opt/domjudge/domserver/webapp/.env.local /opt/domjudge/domserver/webapp/.env.local.php
 fi
 
-sudo -u domjudge make docs
+sudo -u domjudge sh -c '. /venv/bin/activate && make docs'
 make install-docs

--- a/docker/domserver/build.sh
+++ b/docker/domserver/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -eu
 
 # Use venv to use latest Sphinx. 6.1.0 or higher is required to build DOMjudge docs.
+# shellcheck source=/dev/null
 . /venv/bin/activate
 
 cd /domjudge-src/domjudge*

--- a/docker/domserver/build.sh
+++ b/docker/domserver/build.sh
@@ -1,9 +1,5 @@
 #!/bin/sh -eu
 
-# Use venv to use latest Sphinx. 6.1.0 or higher is required to build DOMjudge docs.
-# shellcheck source=/dev/null
-. /venv/bin/activate
-
 cd /domjudge-src/domjudge*
 chown -R domjudge: .
 # If we used a local source tarball, it might not have been built yet
@@ -30,4 +26,7 @@ then
 fi
 
 sudo -u domjudge sh -c '. /venv/bin/activate && make docs'
+# Use Python venv to use the latest Sphinx to build DOMjudge docs.
+# shellcheck source=/dev/null
+. /venv/bin/activate
 make install-docs

--- a/docker/domserver/configure.sh
+++ b/docker/domserver/configure.sh
@@ -23,7 +23,7 @@ done
 
 # Configure php
 
-php_folder=$(echo "/etc/php/7."?"/")
+php_folder=$(echo "/etc/php/8."?"/")
 php_version=$(basename "$php_folder")
 
 if [ ! -d "$php_folder" ]

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt update \
 	&& apt install --no-install-recommends --no-install-suggests -y \
 	dumb-init \
-	acl zip unzip supervisor sudo procps libcgroup1 \
+	acl zip unzip supervisor sudo procps libcgroup2 \
 	php-cli php-zip php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring python3 \
 	gcc g++ default-jre-headless default-jdk ghc fp-compiler \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
* Use Python venv to build domserver because Sphinx version should be 6.1.0 or higher to avoid a build issue.
* Use PHP 8.x because it's default in Debian.
* Use libcgoup2 instead of libcgroup1, which is no longer available.

Fixes #154.