### PR TITLE
Removing breaking part from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ variables:
   timeout: 90 minutes
   parallel:
     matrix:
-      - ARCH: [amd64, arm64v8]
+      - ARCH: [amd64]
 
 .job_template: &ci_template
   script:


### PR DESCRIPTION
We fail on an error with libc-bin:
https://gitlab.com/DOMjudge/domjudge-packaging/-/jobs/5876287000

I got this working in GitHub Actions already so we disable this here and fix this in GHA.