### PR TITLE
Further fix merge-queue failures

### DIFF
--- a/.github/workflows/build-contributor-container-PR.yml
+++ b/.github/workflows/build-contributor-container-PR.yml
@@ -12,6 +12,7 @@ jobs:
   pr-contributor:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
+            github.event.action != 'enqueued' &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-domjudge-container-PR.yml
+++ b/.github/workflows/build-domjudge-container-PR.yml
@@ -13,6 +13,7 @@ jobs:
   pr-domjudge:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
+            github.event.action != 'enqueued' &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-gitlab-container-PR.yml
+++ b/.github/workflows/build-gitlab-container-PR.yml
@@ -10,6 +10,7 @@ jobs:
   pr-gitlab:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
+            github.event.action != 'enqueued' &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     name: PR GitLab image


### PR DESCRIPTION
The branchname would become something hard to read and the branchname chosen by the contributor should already have an image as we work from a PR.