### PR TITLE
Detect mergequeue branch in another way

### DIFF
--- a/.github/workflows/build-contributor-container-PR.yml
+++ b/.github/workflows/build-contributor-container-PR.yml
@@ -12,7 +12,7 @@ jobs:
   pr-contributor:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
-            github.event.action != 'enqueued' &&
+            !contains(github.ref, 'gh-readonly-queue') &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-domjudge-container-PR.yml
+++ b/.github/workflows/build-domjudge-container-PR.yml
@@ -13,7 +13,7 @@ jobs:
   pr-domjudge:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
-            github.event.action != 'enqueued' &&
+            !contains(github.ref, 'gh-readonly-queue') &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-gitlab-container-PR.yml
+++ b/.github/workflows/build-gitlab-container-PR.yml
@@ -10,7 +10,7 @@ jobs:
   pr-gitlab:
     if: ${{ !(github.repository == 'domjudge/domjudge-packaging' &&
               github.ref == 'refs/heads/main') &&
-            github.event.action != 'enqueued' &&
+            !contains(github.ref, 'gh-readonly-queue') &&
             (github.event_name == 'pull_request_target' ||
              github.event.pull_request.head.repo.full_name != github.repository) }}
     name: PR GitLab image


### PR DESCRIPTION
Building the image for the readonly branch is not needed as we already know this should work in the PR, only if someone would force merging before the CI passes we would need this.