### PR TITLE
Find latest version tag which exists on domjudge.org

### DIFF
--- a/.github/workflows/build-domjudge-container-PR.yml
+++ b/.github/workflows/build-domjudge-container-PR.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt update; sudo apt install -y jq curl
           set -x
             HUBURL="https://registry.hub.docker.com/v2/repositories/domjudge/domserver/tags"
-            TAG=$(curl $HUBURL|jq '.results | sort_by(.name) | last.name')
+            TAG=$(curl $HUBURL|jq '.results | sort_by(.name) | .[-2].name')
             DJ_TAG=${TAG//\"}
           set +x
           echo "DOMJUDGE_VERSION=$DJ_TAG" >> $GITHUB_ENV

--- a/.github/workflows/build-domjudge-container-release.yml
+++ b/.github/workflows/build-domjudge-container-release.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt update; sudo apt install jq curl -y
           set -x
             HUBURL="https://registry.hub.docker.com/v2/repositories/domjudge/domserver/tags"
-            TAG=$(curl $HUBURL|jq '.results | sort_by(.name) | last.name')
+            TAG=$(curl $HUBURL|jq '.results | sort_by(.name) | .[-2].name')
             DJ_TAG=${TAG//\"}
           set +x
           echo "DOMJUDGE_VERSION=$DJ_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
We can't use latest as there is no release on domjudge.org with that name, but this makes atleast clear which index we try to get.

This reverts commit 43982ab87f25c623b2f8085e67bca48765279dc1 and improves on it.