### PR TITLE
Don't mount the cgroup as read-only

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -188,7 +188,7 @@ When using the optional Traefik reverse proxy, deploy the stack defined in https
 To run a single judgehost, run the following command:
 
 ```bash
-docker run -it --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name judgehost-0 --net dj --hostname judgedaemon-0 -e DAEMON_ID=0 domjudge/judgehost:latest
+docker run -it --privileged -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost-0 --net dj --hostname judgedaemon-0 -e DAEMON_ID=0 domjudge/judgehost:latest
 ```
 
 Again, replace `latest` with a specific version if desired. Make sure the version matches the version of the domserver.
@@ -242,7 +242,7 @@ echo 127.0.0.1 $(hostname) | sudo tee -a /etc/hosts
 
 ###################################################
 # Fill in these (secret) variables yourself!!
-sudo docker run -d --restart=on-failure --network host --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name judgehost -e DOMSERVER_BASEURL=your_baseurl -e JUDGEDAEMON_USERNAME=your_username -e JUDGEDAEMON_PASSWORD=your_password domjudge/judgehost:7.0.3
+sudo docker run -d --restart=on-failure --network host --privileged -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost -e DOMSERVER_BASEURL=your_baseurl -e JUDGEDAEMON_USERNAME=your_username -e JUDGEDAEMON_PASSWORD=your_password domjudge/judgehost:7.0.3
 ###################################################
 
 # Enable cgroup functionality that judgehost needs, this requires a reboot


### PR DESCRIPTION
Fixes: https://github.com/DOMjudge/domjudge-packaging/issues/193

I wonder why we never had this in the past as we do intent to create the domjudge cgroup in that directory.