### PR TITLE
Clean up docker/build.sh

### DIFF
--- a/.github/workflows/build-domjudge-container-PR.yml
+++ b/.github/workflows/build-domjudge-container-PR.yml
@@ -65,9 +65,7 @@ jobs:
       - name: Build the container
         run: |
           cd docker
-          set -x
-          sh ./build.sh "${{ env.DOMJUDGE_VERSION }}"
-          set +x
+          ./build.sh "${{ env.DOMJUDGE_VERSION }}"
 
       - name: Build and push
         run: |

--- a/.github/workflows/build-domjudge-container-release.yml
+++ b/.github/workflows/build-domjudge-container-release.yml
@@ -65,9 +65,7 @@ jobs:
       - name: Build the container
         run: |
           cd docker
-          set -x
-          sh ./build.sh "${{ env.DOMJUDGE_VERSION }}"
-          set +x
+          ./build.sh "${{ env.DOMJUDGE_VERSION }}"
 
       - name: Build and push
         run: |


### PR DESCRIPTION
 - Move usage check to the top, to serve as documentation for people who read the script.

 - Remove `-x` from shebang line (#!), to only enable tracing in CI.

 - Fix `set -x` call (previously it was inside the `if` condition, which is wrong).

 - ~~Include line numbers etc. in traces (using PS4) on GitHub Actions (previously they were only included on other CI platforms).~~  
   Update: sh doesn't support $LINENO, so remove PS4 entirely instead.

 - Inline `trace_off` into section_start and section_end to produce less noise in the trace.

 - Make the no-op placeholders for section_start and section_end produce less noise in the trace.

 - Redirect stderr to stdout as a workaround for a GitHub Actions issue that causes them to appear out-of-order.

 - Simplify initialisation of NAMESPACE variable to make the trace look nicer.

 - Put the variable assignments in a log group to make it look nicer.

 - Fix the invocation of build.sh in the build-domjudge-container-* workflows to use `./build.sh` rather than `sh ./build.sh` so that the options in the shebang line will be respected. Also remove unnecessary calls to `set -x` in the workflows.