### PR TITLE
Remove obsolete reference to `--link` from docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -126,7 +126,7 @@ With DNS configured, you can now access the web interface on [http://domjudge.ex
 The following environment variables are supported by the `domserver` container:
 
 * `CONTAINER_TIMEZONE` (defaults to `Europe/Amsterdam`): allows you to change the timezone used inside the container.
-* `MYSQL_HOST` (defaults to `mariadb`): set the host to connect to for MySQL. Can be hostname or IP. Docker will add hostnames for any containers you `--link`, so in the example above, the MariaDB container will be available under the hostname `mariadb`.
+* `MYSQL_HOST` (defaults to `mariadb`): set the host to connect to for MySQL. Can be hostname or IP.
 * `MYSQL_USER` (defaults to `domjudge`): set the user to use for connecting to MySQL.
 * `MYSQL_PASSWORD` (defaults to `domjudge`): set the password to use for connecting to MySQL.
 * `MYSQL_ROOT_PASSWORD` (defaults to `domjudge`): set the root password to use for connecting to MySQL.


### PR DESCRIPTION
Commit 62889e12b7 (Add instructions for setting up Traefik in Docker, 2024-02-06) switched from the legacy `--link` option to a user-defined bridge network (`--net`).