### PR TITLE
Preserve ownership of /opt/domjudge set by `make install-*`

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -51,6 +51,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 	FPM_MAX_CHILDREN=40 \
 	DJ_DB_INSTALL_BARE=0
 
+# Set up user
+RUN useradd -m domjudge
+
 # Install required packages for running of domserver
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \

--- a/docker/domserver/configure.sh
+++ b/docker/domserver/configure.sh
@@ -1,9 +1,7 @@
 #!/bin/sh -eu
 
-# Add user, create PHP FPM socket dir, change permissions for domjudge directory and fix scripts
-useradd -m domjudge
+# Create PHP FPM socket dir, change permissions for some domjudge directories and fix scripts
 mkdir -p /run/php
-chown -R domjudge: /opt/domjudge
 chown -R www-data: /opt/domjudge/domserver/tmp
 # for DOMjudge <= 7.2 (submitdir was removed in commit DOMjudge/domjudge@d66725038)
 if [ -d /opt/domjudge/domserver/submissions ]

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -10,6 +10,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 	DOMJUDGE_CREATE_WRITABLE_TEMP_DIR=0 \
 	RUN_USER_UID_GID=62860
 
+# Set up user
+RUN useradd -m domjudge
+
 # Install required packages for running of judgehost
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
@@ -31,7 +34,7 @@ COPY judgehost/scripts /scripts/
 # Make the scripts available to the root user
 ENV PATH="$PATH:/opt/domjudge/judgehost/bin"
 
-# Change start script permissions, add user and fix permissions
+# Run customizations
 COPY judgehost/configure.sh /configure.sh
 RUN chmod 700 /configure.sh && /configure.sh && rm -f /configure.sh
 

--- a/docker/judgehost/configure.sh
+++ b/docker/judgehost/configure.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -e
 
-useradd -m domjudge
-chown -R domjudge: /opt/domjudge
-
 chmod 755 /scripts/start.sh
 for script in /scripts/bin/*
 do


### PR DESCRIPTION
Previously, the DOMjudge Docker scripts changed the ownership of /opt/domjudge to "domjudge" recursively, overriding the ownership set by the DOMjudge installation commands (`make install-domserver` and `make install-judgehost`), which mostly set the owner to "root".

It is unclear why the Docker scripts did that, since the DOMjudge installation commands should be responsible for installing with the correct ownership.

This commit removes the `chown -R` calls from the Docker scripts in order to preserve the ownership set by the DOMjudge installation commands and avoid security issues.

Note that the new behaviour is slightly fragile because it relies on Docker's `COPY --from` directive to preserve the ownership when copying files between build stages, and that only works if the numerical user and group IDs are the same. We plan to add a check that the IDs are the same.