### PR TITLE
Drop support for building containers DOMjudge <8.0

### DIFF
--- a/docker/domserver/build.sh
+++ b/docker/domserver/build.sh
@@ -8,22 +8,12 @@ sudo -u domjudge ./configure -with-baseurl=http://localhost/
 
 # Passwords should not be included in the built image. We create empty files here to prevent passwords from being generated.
 sudo -u domjudge touch etc/dbpasswords.secret etc/restapi.secret etc/symfony_app.secret etc/initial_admin_password.secret
-if [ ! -f webapp/config/load_db_secrets.php ]
-then
-	# DOMjudge 7.1
-	sudo -u domjudge touch webapp/.env.local webapp/.env.local.php
-fi
 
 sudo -u domjudge make domserver
 make install-domserver
 
 # Remove installed password files
 rm /opt/domjudge/domserver/etc/*.secret
-if [ ! -f webapp/config/load_db_secrets.php ]
-then
-	# DOMjudge 7.1
-	rm /opt/domjudge/domserver/webapp/.env.local /opt/domjudge/domserver/webapp/.env.local.php
-fi
 
 sudo -u domjudge sh -c '. /venv/bin/activate && make docs'
 # Use Python venv to use the latest Sphinx to build DOMjudge docs.

--- a/docker/domserver/configure.sh
+++ b/docker/domserver/configure.sh
@@ -3,11 +3,6 @@
 # Create PHP FPM socket dir, change permissions for some domjudge directories and fix scripts
 mkdir -p /run/php
 chown -R www-data: /opt/domjudge/domserver/tmp
-# for DOMjudge <= 7.2 (submitdir was removed in commit DOMjudge/domjudge@d66725038)
-if [ -d /opt/domjudge/domserver/submissions ]
-then
-	chown -R www-data: /opt/domjudge/domserver/submissions
-fi
 
 chmod 755 /scripts/start.sh
 for script in /scripts/bin/*


### PR DESCRIPTION
We assume PHP8 already in the scripts, so I suspect this did not work anymore. When someone wants such an older version they can still check the history for the current files and alter the setup from there.