### PR TITLE
Update the command to package the local source into a Docker image.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -263,8 +263,10 @@ where `version` is the DOMjudge version to create the images for, e.g. `5.3.0`.
 
 To build domjudge with local sources, run
 ```bash
-  tar --exclude-vcs -czf <path to domjudge-packaging>/docker/domjudge.tar.gz <domjudge source directory>
-  cd <path to domjudge-packaging>/docker
+  dpkp=<path to domjudge-packaging>
+  dj=<domjudge source directory>
+  tar --exclude-vcs -czf $dpkp/docker/domjudge.tar.gz -C $(dirname "$dj") $(basename "$dj")
+  cd $dpkp/docker
   docker build -t domjudge -f domserver/Dockerfile .
 ```
 Note that the source directory name has to match `domjudge-*`.


### PR DESCRIPTION
When packaging my local source into a package, I encountered an error because I didn't execute the command in the parent directory of DOMjudge. It took me some time to realize the issue when I initially filled in the absolute path for `<domjudge source directory>`.

I believe it should be mentioned in the README to execute the command in the parent directory of DOMjudge, or the changes made in this PR could help avoid this issue.