### PR TITLE
Add ppa:pypy/ppa repository in Dockerfiles of judgehost and gitlabci

### DIFF
--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -7,7 +7,8 @@ RUN useradd -d /nonexistent -g nogroup -s /bin/false domjudge-run-0
 RUN useradd -d /nonexistent -g nogroup -s /bin/false domjudge-run-1
 RUN groupadd domjudge-run
 
-RUN apt-get update && apt-get install -y \
+RUN apt-add-repository ppa:pypy/ppa -y \
+  apt-get update && apt-get -y install \
   acl make zip unzip apache2-utils bsdmainutils libcurl4-gnutls-dev \
   libjsoncpp-dev libmagic-dev autoconf automake bats sudo debootstrap procps \
   gcc g++ default-jre-headless default-jdk-headless ghc fp-compiler libcgroup-dev \

--- a/docker/judgehost/Dockerfile.chroot
+++ b/docker/judgehost/Dockerfile.chroot
@@ -1,6 +1,7 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install \
+RUN apt-add-repository ppa:pypy/ppa -y \
+  apt-get update && apt-get -y install \
   ca-certificates default-jre-headless pypy3 locales \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This makes sure that the `pypy3` package is always the latest, which is nice for always having the newest possible Python language level. Currently, Ubuntu 24.04 (Noble Numbat) has `pypy3` 7.3.15 (with Python 3.9) and this will probably stay like this for a while, but `pypy3` 7.3.17 already supports Python 3.10.

These were the only two occurrences of `apt-get install [...] pypy3 [...]` that I could find, please let me know if I missed something. For example, I don't know how the judgehosts end up in the docker-contributor image.

Also, for some reason, `docker/judgehost/Dockerfile.chroot` was still based on Ubuntu 20.04, so I also updated that :slightly_smiling_face: 