### PR TITLE
Add Apache2 configuration to docker-contributor

### DIFF
--- a/docker-contributor/Dockerfile
+++ b/docker-contributor/Dockerfile
@@ -16,6 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
   DJ_DB_INSTALL_BARE=0 \
   PHPSUPPORTED="8.1 8.2 8.3" \
   DEFAULTPHPVERSION="8.3" \
+  DEFAULTWEBSERVER="nginx" \
   APTINSTALL="apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 
 # Install required packages and clean up afterwards to make this image layer smaller

--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -9,7 +9,7 @@ The container includes the following:
  * Set up or update the database.
  * Set up the webserver.
  * Create a chroot.
-* PHP-FPM and nginx for running the web interface.
+* PHP-FPM and apache2 or nginx for running the web interface.
 * Two running judgedaemons using a chroot.
 * Scripts for reading the log files of the webserver and the judgedaemons.
 * A script to create a dummy DOMjudge user and submit all test submissions.
@@ -67,6 +67,7 @@ The following environment variables are supported by the container:
 * `MYSQL_DATABASE` (defaults to `domjudge`): set the database to use.
 * `FPM_MAX_CHILDREN` (defaults to `40`): the maximum number of PHP FPM children to spawn.
 * `DJ_SKIP_MAKE` (defaults to `0`): set to `1` to skip the maintainer setup and install commands. This will speed up the startup process of the container and is useful if this is already done before.
+* `DEFAULTWEBSERVER` (defaults to `nginx`): set to `apache2` to use the Apache2 httpd server as default webserver.
 
 #### Passwords through files
 
@@ -97,6 +98,8 @@ If you have named your container something other than `domjudge`, be sure to cha
 
 The following commands are available:
 
+* `apache2-access-log`: tail the access log of apache2.
+* `apache2-error-log`: tail the error log of apache2.
 * `nginx-access-log`: tail the access log of nginx.
 * `nginx-error-log`: tail the error log of nginx.
 * `judgedaemon-log 0` and `judgedaemon-log 1`: tail the log of the first / second judgeaemon.
@@ -105,6 +108,7 @@ The following commands are available:
 * `xdebug-enable`: enable Xdebug debugging. See note below
 * `xdebug-disable`: disable Xdebug debugging. See note below
 * `switch-php <version>`: switch to using the given PHP version.
+* `switch-webserver <apache2|nginx>`: switch to using the given webserver.
 
 Of course, you can always run `docker exec -it domjudge bash` to get a bash shell inside the container.
 
@@ -114,7 +118,7 @@ To restart any of the services, run the following:
 docker exec -it domjudge supervisorctl restart [service]
 ```
 
-where `[service]` is one of `nginx`, `php`, `judgedaemon0` or `judgedaemon1`.
+where `[service]` is one of `apache2`, `nginx`, `php`, `judgedaemon0` or `judgedaemon1`.
 
 ### Xdebug
 

--- a/docker-contributor/scripts/bin/apache2-access-log
+++ b/docker-contributor/scripts/bin/apache2-access-log
@@ -1,0 +1,2 @@
+#!/bin/bash
+supervisorctl tail -f apache2

--- a/docker-contributor/scripts/bin/apache2-error-log
+++ b/docker-contributor/scripts/bin/apache2-error-log
@@ -1,0 +1,2 @@
+#!/bin/bash
+supervisorctl tail -f apache2 stderr

--- a/docker-contributor/scripts/bin/switch-webserver
+++ b/docker-contributor/scripts/bin/switch-webserver
@@ -1,0 +1,14 @@
+#!/bin/bash
+WEBSERVER=$1
+if [ "${WEBSERVER}" = "nginx" ]
+then
+  sudo supervisorctl stop apache2
+  sudo supervisorctl start nginx
+elif [ "${WEBSERVER}" = "apache2" ]
+then
+  sudo supervisorctl stop nginx
+  sudo supervisorctl start apache2
+else
+  echo "Usage: $0 [apache2|nginx]"
+  exit 1
+fi

--- a/docker-contributor/supervisor/apache2.conf
+++ b/docker-contributor/supervisor/apache2.conf
@@ -1,0 +1,5 @@
+[program:apache2]
+command=pidproxy /var/run/apache2/apache2.pid /bin/bash -c "source /etc/apache2/envvars && apache2ctl -D FOREGROUND"
+numprocs=1
+autostart=false
+autorestart=true

--- a/docker-contributor/supervisor/nginx.conf
+++ b/docker-contributor/supervisor/nginx.conf
@@ -1,5 +1,5 @@
 [program:nginx]
 command=nginx -g "daemon off;"
 numprocs=1
-autostart=true
+autostart=false
 autorestart=true


### PR DESCRIPTION
Adding configuration for Apache2 enables easier testing of webserver-specific features and issues.

By default, the contributor image still uses NGINX as webserver. Add an option to use Apache2 by default, or switch back and forth between NGINX/Apache2 with the `switch-webserver` command.

I played around with configuring Apache2 in the container for https://github.com/DOMjudge/domjudge/pull/2740. As it is relatively straight-forward, I think it is nice to include in the image.