### PR TITLE
Allow reading the SQL logs for CI

### DIFF
--- a/docker-gitlabci/Dockerfile
+++ b/docker-gitlabci/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
   texlive-latex-recommended texlive-latex-extra texlive-lang-european latexmk \
   # Misc gitlab things \
   mariadb-client curl build-essential packaging-dev  \
-  git python3-pip moreutils w3m python3-yaml \
+  git python3-pip moreutils w3m python3-yaml docker.io \
   # Things we'd have in the chroot \
   ca-certificates default-jre-headless pypy3 locales software-properties-common \
   # W3c WCAG \


### PR DESCRIPTION
We need Docker to read the logs of the GHA services.