### PR TITLE
Needs pv for dumping database

### DIFF
--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -57,7 +57,7 @@ RUN useradd -m domjudge
 # Install required packages for running of domserver
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	acl curl zip unzip supervisor mariadb-client apache2-utils \
+	acl curl zip unzip supervisor mariadb-client pv apache2-utils \
 	nginx php-cli php-fpm php-zip \
 	php-gd php-curl php-mysql php-json php-intl \
 	php-gmp php-xml php-mbstring php-ldap \


### PR DESCRIPTION
`pv` should be installed for dumping the database. This tool is installed in `docker-gitlabci` and `docker-contributor`, but not in `docker`.