### PR TITLE
Fix the name of the release workflows

### DIFF
--- a/.github/workflows/build-contributor-container-release.yml
+++ b/.github/workflows/build-contributor-container-release.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   release-contributor:
+    name: Release Contributor image
     if: ${{ github.repository == 'domjudge/domjudge-packaging' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-domjudge-container-release.yml
+++ b/.github/workflows/build-domjudge-container-release.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   release-domjudge:
+    name: Release DOMjudge docker image(s)
     if: ${{ github.repository == 'domjudge/domjudge-packaging' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-gitlab-container-release.yml
+++ b/.github/workflows/build-gitlab-container-release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-gitlab:
+    name: Release GitLab image
     if: ${{ github.repository == 'domjudge/domjudge-packaging' }}
     name: Build GitLab image
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes them easier to find in the GH UI for selecting the required checks.