### PR TITLE
Migrate container to ubuntu:26.04

### DIFF
--- a/.github/jobs/check-domjudge-container.sh
+++ b/.github/jobs/check-domjudge-container.sh
@@ -51,7 +51,7 @@ ss -tulpn
 # Connect to SQL
 docker exec -t "$DOCKER_DB" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD"                     -e "SHOW DATABASES;"
 docker exec -t "$DOCKER_DB" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -D"$MYSQL_DATABASE" -e "SHOW TABLES;"
-docker exec -t "$DOCKER_DOMSERVER" mysqlshow -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -h"$DOCKER_DB" "$MYSQL_DATABASE"
+docker exec -t "$DOCKER_DOMSERVER" mariadb-show -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -h"$DOCKER_DB" "$MYSQL_DATABASE"
 
 # Show we indeed waited 3*60 seconds for 10*10 seconds checks,
 timeout --preserve-status 180 docker logs -f "$DOCKER_DOMSERVER" || true

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS domserver-build
+FROM ubuntu:26.04 AS domserver-build
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,7 +28,7 @@ COPY domserver/build.sh /domjudge-src/build.sh
 RUN /domjudge-src/build.sh
 
 # Now create an image with the actual build in it
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -48,7 +48,7 @@ RUN useradd -m domjudge
 # Install required packages for running of domserver
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	acl zip curl supervisor mariadb-client pv \
+	acl zip curl supervisor mariadb-client pv iproute2 \
 	nginx composer php-fpm php-zip php-bcmath \
 	php-ds php-gd php-mysql php-json php-intl php-gmp \
 	php-xml php-mbstring python3-yaml python3-requests enscript lpr \

--- a/docker/domserver/scripts/start.d/50-domjudge.sh
+++ b/docker/domserver/scripts/start.d/50-domjudge.sh
@@ -144,7 +144,7 @@ DB_UP=9
 while [ $DB_UP -gt 0 ]
 do
 	echo "[..] Checking database connection"
-	if ! mysqlshow -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
+	if ! mariadb-show -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
 	then
 		echo "MySQL database ${MYSQL_DATABASE} not yet found on host ${MYSQL_HOST}:${MYSQL_PORT};"
 		(( DB_UP-- ))
@@ -153,7 +153,7 @@ do
 		DB_UP=0
 	fi
 done
-if ! mysqlshow -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
+if ! mariadb-show -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
 then
 	echo "MySQL database ${MYSQL_DATABASE} not found on host ${MYSQL_HOST}:${MYSQL_PORT}; exiting"
 	exit 1

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -17,7 +17,7 @@ RUN useradd -m domjudge
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 	dumb-init pkg-config \
-	acl lsof zip unzip supervisor sudo procps libcgroup2 \
+	acl lsof zip unzip supervisor sudo procps libcgroup-dev \
 	php-cli php-zip php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring python3 \
 	gcc g++ default-jre-headless default-jdk-headless ghc fp-compiler \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 LABEL org.opencontainers.image.authors="DOMjudge team <team@domjudge.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,7 @@ RUN apt-get update \
 	php-cli php-zip lsb-release debootstrap \
 	php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring composer \
-	sudo bsdmainutils ntp libcgroup-dev procps \
+	sudo bsdmainutils libcgroup-dev procps \
 	libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
 	ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The former PR #260 did not fully resolve the issue. After installing `php-ds`, PHP complains:

```text
PHP Warning:  PHP Startup: Unable to load dynamic library 'ds.so' (tried: /usr/lib/php/20230831/ds.so (/usr/lib/php/20230831/ds.so: undefined symbol: fast_add_function), /usr/lib/php/20230831/ds.so.so (/usr/lib/php/20230831/ds.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
```

It is caused by a compatibility bug in php-ds v1.4 (https://github.com/php-ds/ext-ds/issues/199), which makes php-ds v1.4 incompatible with PHP 8.3. v1.5 fixed the issue, but the source pool of Ubuntu 24.04 only contains v1.4 (https://launchpad.net/ubuntu/+source/php-ds). So this PR uses newer php-ds in `ppa:ondrej/php` to solve the issue.

~~Tested on my own server.~~