### PR TITLE
Fix cgroup volume flags in docker run examples

### DIFF
--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -37,7 +37,7 @@ Next, if you are on Linux make sure you have cgroups enabled. See the [DOMjudge 
 Now you can run DOMjudge itself using the following command:
 
 ```bash
-docker run -v [path-to-domjudge-checkout]:[path-to-domjudge-checkout] -v /sys/fs/cgroup:/sys/fs/cgroup:ro --link dj-mariadb:mariadb -it -e UID="$(id -u)" -e GID="$(id -g)" -e PROJECT_DIR=[path-to-domjudge-checkout] -p 12345:80 --name domjudge --privileged domjudge/domjudge-contributor
+docker run -v [path-to-domjudge-checkout]:[path-to-domjudge-checkout] -v /sys/fs/cgroup:/sys/fs/cgroup --cgroupns=host --link dj-mariadb:mariadb -it -e UID="$(id -u)" -e GID="$(id -g)" -e PROJECT_DIR=[path-to-domjudge-checkout] -p 12345:80 --name domjudge --privileged domjudge/domjudge-contributor
 ```
 
 Make sure you replace `[path-to-domjudge-checkout]` with the path to your local DOMjudge checkout. On recent macOS and Windows Docker builds, you should add `:cached` at the end of the volume (i.e. `-v [path-to-domjudge-checkout]:[path-to-domjudge-checkout]:cached`) to speed up the webserver a lot.

--- a/docker/README.md
+++ b/docker/README.md
@@ -189,7 +189,7 @@ where `[service]` is one of `nginx` or `php`.
 To run a single judgehost, run the following command:
 
 ```bash
-docker run -it --privileged -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost-0 --net dj --hostname judgedaemon-0 -e DAEMON_ID=0 domjudge/judgehost:latest
+docker run -it --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost-0 --net dj --hostname judgedaemon-0 -e DAEMON_ID=0 domjudge/judgehost:latest
 ```
 
 Again, replace `latest` with a specific version if desired. Make sure the version matches the version of the domserver.
@@ -243,7 +243,7 @@ echo 127.0.0.1 $(hostname) | sudo tee -a /etc/hosts
 
 ###################################################
 # Fill in these (secret) variables yourself!!
-sudo docker run -d --restart=on-failure --network host --privileged -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost -e DOMSERVER_BASEURL=your_baseurl -e JUDGEDAEMON_USERNAME=your_username -e JUDGEDAEMON_PASSWORD=your_password domjudge/judgehost:7.0.3
+sudo docker run -d --restart=on-failure --network host --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup --name judgehost -e DOMSERVER_BASEURL=your_baseurl -e JUDGEDAEMON_USERNAME=your_username -e JUDGEDAEMON_PASSWORD=your_password domjudge/judgehost:7.0.3
 ###################################################
 
 # Enable cgroup functionality that judgehost needs, this requires a reboot


### PR DESCRIPTION
This adds --cgroupns=host to judgehost/contributor docker run commands. Without it, Docker 20.10+ uses a private cgroup namespace, making create_cgroups fail with a following message:
> Error: Cgroups not configured properly, missing cgroup hierarchy prefix under /proc/self/cgroup. If running in a container, make sure to set cgroupns=host.

Also remove the stale :ro flag from the docker-contributor example. create_cgroups writes to /sys/fs/cgroup/cgroup.subtree_control so a read-only mount is not correct there, which was fixed by a commit 2608426 in docker, but never in docker-contributor.