### PR TITLE
Fixes prepared for new base image

### DIFF
--- a/.github/jobs/check-domjudge-container.sh
+++ b/.github/jobs/check-domjudge-container.sh
@@ -51,7 +51,7 @@ ss -tulpn
 # Connect to SQL
 docker exec -t "$DOCKER_DB" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD"                     -e "SHOW DATABASES;"
 docker exec -t "$DOCKER_DB" mariadb -uroot -p"$MYSQL_ROOT_PASSWORD" -D"$MYSQL_DATABASE" -e "SHOW TABLES;"
-docker exec -t "$DOCKER_DOMSERVER" mysqlshow -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -h"$DOCKER_DB" "$MYSQL_DATABASE"
+docker exec -t "$DOCKER_DOMSERVER" mariadb-show -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" -h"$DOCKER_DB" "$MYSQL_DATABASE"
 
 # Show we indeed waited 3*60 seconds for 10*10 seconds checks,
 timeout --preserve-status 180 docker logs -f "$DOCKER_DOMSERVER" || true

--- a/docker/domserver/Dockerfile
+++ b/docker/domserver/Dockerfile
@@ -48,7 +48,7 @@ RUN useradd -m domjudge
 # Install required packages for running of domserver
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
-	acl zip curl supervisor mariadb-client pv \
+	acl zip curl supervisor mariadb-client pv iproute2 \
 	nginx composer php-fpm php-zip php-bcmath \
 	php-ds php-gd php-mysql php-json php-intl php-gmp \
 	php-xml php-mbstring python3-yaml python3-requests enscript lpr \

--- a/docker/domserver/scripts/start.d/50-domjudge.sh
+++ b/docker/domserver/scripts/start.d/50-domjudge.sh
@@ -144,7 +144,7 @@ DB_UP=9
 while [ $DB_UP -gt 0 ]
 do
 	echo "[..] Checking database connection"
-	if ! mysqlshow -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
+	if ! mariadb-show -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
 	then
 		echo "MySQL database ${MYSQL_DATABASE} not yet found on host ${MYSQL_HOST}:${MYSQL_PORT};"
 		(( DB_UP-- ))
@@ -153,7 +153,7 @@ do
 		DB_UP=0
 	fi
 done
-if ! mysqlshow -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
+if ! mariadb-show -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" -h"${MYSQL_HOST}" -P "${MYSQL_PORT}" "${MYSQL_DATABASE}" > /dev/null 2>&1
 then
 	echo "MySQL database ${MYSQL_DATABASE} not found on host ${MYSQL_HOST}:${MYSQL_PORT}; exiting"
 	exit 1

--- a/docker/judgehost/Dockerfile
+++ b/docker/judgehost/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -m domjudge
 RUN apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 	dumb-init pkg-config \
-	acl lsof zip unzip supervisor sudo procps libcgroup2 \
+	acl lsof zip unzip supervisor sudo procps libcgroup-dev \
 	php-cli php-zip php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring python3 \
 	gcc g++ default-jre-headless default-jdk-headless ghc fp-compiler \

--- a/docker/judgehost/Dockerfile.build
+++ b/docker/judgehost/Dockerfile.build
@@ -14,7 +14,7 @@ RUN apt-get update \
 	php-cli php-zip lsb-release debootstrap \
 	php-gd php-curl php-mysql php-json \
 	php-gmp php-xml php-mbstring composer \
-	sudo bsdmainutils ntp libcgroup-dev procps \
+	sudo bsdmainutils libcgroup-dev procps \
 	libcurl4-gnutls-dev libjsoncpp-dev libmagic-dev \
 	ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
1. `mysqlshow` is an alias of `mariadb-show` from MariaDB 10.5 and is removed from newer sources.
2. Newer images (`debian:trixie` and `ubuntu:26.04`) do not have `ip` built in (which is used in `50-domjudge.sh` to find the docker gateway); install `iproute2` to use the utility.
3. Newer images (`debian:trixie` and `ubuntu:26.04`) do not have `libcgroup2` in the source. Install `libcgroup-dev` as other scripts do.
4. Newer images (`debian:trixie` and `ubuntu:26.04`) do not have `ntp` in the source. Remove it since we do not need it when building judgehost.

Tested on my local server.