### PR TITLE
Allow passing additional configure steps for contributor container

### DIFF
--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -70,6 +70,7 @@ The following environment variables are supported by the container:
 * `DEFAULTWEBSERVER` (defaults to `nginx`): set to `apache2` to use the Apache2 httpd server as default webserver.
 * `NUMBER_INITIAL_JUDGEDAEMONS` (defaults to `2`): set to 0 or any positive number to regulate the number of initial judgedaemons.
 * `JUDGEDAEMON_SKIP` (defaults to ``): set to disable setup of any judgedaemon scripts/settings.
+* `PROJECT_DIR` (defaults to '/domjudge'): set to alternative DOMjudge sources directory.
 
 #### Passwords through files
 

--- a/docker-contributor/README.md
+++ b/docker-contributor/README.md
@@ -71,6 +71,7 @@ The following environment variables are supported by the container:
 * `NUMBER_INITIAL_JUDGEDAEMONS` (defaults to `2`): set to 0 or any positive number to regulate the number of initial judgedaemons.
 * `JUDGEDAEMON_SKIP` (defaults to ``): set to disable setup of any judgedaemon scripts/settings.
 * `PROJECT_DIR` (defaults to '/domjudge'): set to alternative DOMjudge sources directory.
+* `EXTRA_CONFIGURE_FLAGS` (defaults to ''): set to pass additional configure flags. For example to disable docs generation, alternative webserver alias.
 
 #### Passwords through files
 

--- a/docker-contributor/scripts/start.sh
+++ b/docker-contributor/scripts/start.sh
@@ -69,7 +69,7 @@ then
   echo "Skipping maintainer-mode install for DOMjudge"
 else
   echo "[..] Performing maintainer-mode install for DOMjudge"
-  su - domjudge -c "cd ${PROJECT_DIR} && make maintainer-conf CONFIGURE_FLAGS='--with-baseurl=http://localhost/ --with-webserver-group=domjudge'"
+  su - domjudge -c "cd ${PROJECT_DIR} && make maintainer-conf CONFIGURE_FLAGS='--with-baseurl=http://localhost/ --with-webserver-group=domjudge ${EXTRA_CONFIGURE_FLAGS}'"
   su - domjudge -c "cd ${PROJECT_DIR} && make maintainer-install"
   echo "[ok] DOMjudge installed in Maintainer-mode"; echo
 fi


### PR DESCRIPTION
In this specific case I need it to pass the `alias` for the webserver for a test setup but this is also useful to disable documentation generation to speed up the start of the setup.